### PR TITLE
Users and groups management APIs for OpenLDAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Change the group description
 
 Create user `first.user` as member of `mygroup1`
 
-    api-cli run module/openldap1/add-user --data '{"user":"first.user","full_name":"First User","password":"Nethesis,1234","groups":["mygroup1"]}'
+    api-cli run module/openldap1/add-user --data '{"user":"first.user","display_name":"First User","password":"Nethesis,1234","groups":["mygroup1"]}'
 
 Change First User's password
 

--- a/README.md
+++ b/README.md
@@ -73,4 +73,4 @@ Create user `first.user` as member of `mygroup1`
 
 Change First User's password
 
-    api-cli run module/openldap1/alter-user --data '{"user":"usr1","password":"Neth,123"}'
+    api-cli run module/openldap1/alter-user --data '{"user":"first.user","password":"Neth,123"}'

--- a/README.md
+++ b/README.md
@@ -56,3 +56,21 @@ are sent to stderr, which is forwarded to Systemd journal. Set
     systemctl --user restart openldap
 
 See also the server README.
+
+## Users and group management APIs
+
+Create group `mygroup1`
+
+    api-cli run module/openldap1/add-group --data '{"group":"mygroup1","description":"My group","users":[]}'
+
+Change the group description
+
+    api-cli run module/openldap1/alter-group --data '{"group":"mygroup1","description":"My Group 1"}'
+
+Create user `first.user` as member of `mygroup1`
+
+    api-cli run module/openldap1/add-user --data '{"user":"first.user","full_name":"First User","password":"Nethesis,1234","groups":["mygroup1"]}'
+
+Change First User's password
+
+    api-cli run module/openldap1/alter-user --data '{"user":"usr1","password":"Neth,123"}'

--- a/imageroot/actions/add-group/01validate_group
+++ b/imageroot/actions/add-group/01validate_group
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (C) 2021 Nethesis S.r.l.
+# Copyright (C) 2022 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
 #
 # This script is part of NethServer.
@@ -20,24 +20,20 @@
 # along with NethServer.  If not, see COPYING.
 #
 
+import os
+import sys
 import agent
 import json
-import sys
 import subprocess
 
+agent.set_weight(os.path.basename(__file__), 0) # Validation step, no task progress at all
 request = json.load(sys.stdin)
 group = request['group']
-users = request['users']
-description = request.get('description', '')
+domsuffix = os.environ['LDAP_SUFFIX']
 
-addgroup_cmd = [
-    'podman', 'exec', 'openldap', 'add-group',
-    '-u', ','.join(users),
-]
-
-if description:
-    addgroup_cmd += ['-d', description]
-
-addgroup_cmd.append(group)
-
-subprocess.run(addgroup_cmd, stdout=sys.stderr, check=True, text=True)
+testexists_cmd = ['podman', 'exec', 'openldap', 'ldapsearch', '-s', 'base', '-b', f'cn={group},ou=Groups,{domsuffix}']
+proc = subprocess.run(testexists_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)
+if proc.returncode == 0:
+    agent.set_status('validation-failed')
+    json.dump([{'field':'group', 'parameter':'group','value': group, 'error':'group_already_exists'}], fp=sys.stdout)
+    sys.exit(2)

--- a/imageroot/actions/add-group/50add_group
+++ b/imageroot/actions/add-group/50add_group
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import agent
+import json
+import sys
+import subprocess
+
+request = json.load(sys.stdin)
+group = request['group']
+users = request['users']
+description = request['description']
+
+addgroup_cmd = [
+    'podman', 'exec', 'openldap', 'add-group',
+    '-u', ','.join(users),
+]
+
+if description:
+    addgroup_cmd += ['-d', description]
+
+addgroup_cmd.append(group)
+
+subprocess.run(addgroup_cmd, stdout=sys.stderr, check=True, text=True)

--- a/imageroot/actions/add-group/validate-input.json
+++ b/imageroot/actions/add-group/validate-input.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "add-group input",
+    "$id": "http://schema.nethserver.org/openldap/add-group-input.json",
+    "description": "Add a group of users to the LDAP database",
+    "examples": [
+        {
+            "group": "developers",
+            "description": "",
+            "users": [
+                "bob",
+                "alice"
+            ]
+        }
+    ],
+    "type": "object",
+    "required": [
+        "group",
+        "users"
+    ],
+    "properties": {
+        "group": {
+            "title": "Group identifier",
+            "type": "string",
+            "minLength": 1
+        },
+        "description": {
+            "title": "Extended group description",
+            "type":"string"
+        },
+        "users": {
+            "title": "Group members",
+            "type":"array",
+            "items": {
+                "title": "User identifier",
+                "type": "string",
+                "minLength": 1,
+                "uniqueItems": true
+            }
+        }
+    },
+    "$defs": {}
+}

--- a/imageroot/actions/add-group/validate-input.json
+++ b/imageroot/actions/add-group/validate-input.json
@@ -25,8 +25,9 @@
             "minLength": 1
         },
         "description": {
-            "title": "Extended group description",
-            "type":"string"
+            "title": "Group description",
+            "type":"string",
+            "maxLength": 256
         },
         "users": {
             "title": "Group members",

--- a/imageroot/actions/add-user/01validate_user
+++ b/imageroot/actions/add-user/01validate_user
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (C) 2021 Nethesis S.r.l.
+# Copyright (C) 2022 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
 #
 # This script is part of NethServer.
@@ -20,24 +20,20 @@
 # along with NethServer.  If not, see COPYING.
 #
 
+import os
+import sys
 import agent
 import json
-import sys
 import subprocess
 
+agent.set_weight(os.path.basename(__file__), 0) # Validation step, no task progress at all
 request = json.load(sys.stdin)
-group = request['group']
-users = request['users']
-description = request.get('description', '')
+user = request['user']
+domsuffix = os.environ['LDAP_SUFFIX']
 
-addgroup_cmd = [
-    'podman', 'exec', 'openldap', 'add-group',
-    '-u', ','.join(users),
-]
-
-if description:
-    addgroup_cmd += ['-d', description]
-
-addgroup_cmd.append(group)
-
-subprocess.run(addgroup_cmd, stdout=sys.stderr, check=True, text=True)
+testexists_cmd = ['podman', 'exec', '-i', 'openldap', 'ldapsearch', '-s', 'base', '-b', f'uid={user},ou=People,{domsuffix}']
+proc = subprocess.run(testexists_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)
+if proc.returncode == 0:
+    agent.set_status('validation-failed')
+    json.dump([{'field':'user', 'parameter':'user','value': user, 'error':'user_already_exists'}], fp=sys.stdout)
+    sys.exit(2)

--- a/imageroot/actions/add-user/50add_user
+++ b/imageroot/actions/add-user/50add_user
@@ -27,18 +27,23 @@ import subprocess
 
 request = json.load(sys.stdin)
 user = request['user']
-groups = request['groups']
+groups = request.get('groups', [])
 password = request.get('password', '') # Empty string implies a random password is set
-full_name = request['full_name']
+display_name = request.get('display_name', '')
 
-adduser_cmd = [
-    'podman', 'exec', '-i', 'openldap', 'add-user',
-    '-g', ','.join(groups),
-    '-p', '-', # Read password from stdin
-]
+adduser_cmd = ['podman', 'exec', '-i', 'openldap', 'add-user']
 
-if full_name:
-    adduser_cmd += ['-f', full_name]
+if groups:
+    adduser_cmd += ['-g', ','.join(groups)]
+
+if password:
+    adduser_cmd += ['-p', '-'] # Read password from stdin
+else:
+    password=None
+    adduser_cmd += ['-p', ''] # Generate a random password
+
+if display_name:
+    adduser_cmd += ['-d', display_name]
 
 adduser_cmd.append(user)
 

--- a/imageroot/actions/add-user/50add_user
+++ b/imageroot/actions/add-user/50add_user
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import agent
+import json
+import sys
+import subprocess
+
+request = json.load(sys.stdin)
+user = request['user']
+groups = request['groups']
+password = request.get('password', '') # Empty string implies a random password is set
+full_name = request['full_name']
+
+adduser_cmd = [
+    'podman', 'exec', '-i', 'openldap', 'add-user',
+    '-g', ','.join(groups),
+    '-p', '-', # Read password from stdin
+]
+
+if full_name:
+    adduser_cmd += ['-f', full_name]
+
+adduser_cmd.append(user)
+
+subprocess.run(adduser_cmd, input=password, stdout=sys.stderr, check=True, text=True)

--- a/imageroot/actions/add-user/validate-input.json
+++ b/imageroot/actions/add-user/validate-input.json
@@ -7,7 +7,7 @@
     "examples": [
         {
             "user": "alice",
-            "full_name": "Alice Jordan",
+            "display_name": "Alice Jordan",
             "password": "secret",
             "groups": [
                 "developers"
@@ -15,9 +15,7 @@
         }
     ],
     "required": [
-        "user",
-        "full_name",
-        "groups"
+        "user"
     ],
     "properties": {
         "user": {
@@ -27,17 +25,16 @@
             "maxLength": 255,
             "pattern": "^[a-z][-._a-z0-9]*$"
         },
-        "full_name": {
-            "title": "Full name",
+        "display_name": {
+            "title": "Display name",
             "type": "string",
-            "minLength": 1,
-            "maxLength": 32
+            "maxLength": 256
         },
         "password": {
             "title": "Initial password",
             "description": "If missing, a random password is set",
             "type": "string",
-            "minLength": 1
+            "maxLength": 256
         },
         "groups": {
             "title": "Initial group membership",

--- a/imageroot/actions/add-user/validate-input.json
+++ b/imageroot/actions/add-user/validate-input.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "add-user input",
+    "$id": "http://schema.nethserver.org/openldap/add-user-input.json",
+    "description": "Add a user to the LDAP database",
+    "type": "object",
+    "examples": [
+        {
+            "user": "alice",
+            "full_name": "Alice Jordan",
+            "password": "secret",
+            "groups": [
+                "developers"
+            ]
+        }
+    ],
+    "required": [
+        "user",
+        "full_name",
+        "groups"
+    ],
+    "properties": {
+        "user": {
+            "title": "User identifier",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "pattern": "^[a-z][-._a-z0-9]*$"
+        },
+        "full_name": {
+            "title": "Full name",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 32
+        },
+        "password": {
+            "title": "Initial password",
+            "description": "If missing, a random password is set",
+            "type": "string",
+            "minLength": 1
+        },
+        "groups": {
+            "title": "Initial group membership",
+            "description": "Set the user as a member of the given list of groups",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "type": "string",
+                "minLength": 1
+            }
+        }
+    },
+    "$defs": {}
+}

--- a/imageroot/actions/alter-group/50alter_group
+++ b/imageroot/actions/alter-group/50alter_group
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import agent
+import json
+import sys
+import subprocess
+
+request = json.load(sys.stdin)
+group = request['group']
+
+altergroup_cmd = ['podman', 'exec', 'openldap', 'alter-group']
+
+if 'users' in request:
+    altergroup_cmd += ['-u', ','.join(request['users'])]
+
+if 'description' in request:
+    altergroup_cmd += ['-d', request['description']]
+
+altergroup_cmd.append(group)
+
+subprocess.run(altergroup_cmd, stdout=sys.stderr, check=True, text=True)

--- a/imageroot/actions/alter-group/validate-input.json
+++ b/imageroot/actions/alter-group/validate-input.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "alter-group input",
+    "$id": "http://schema.nethserver.org/openldap/alter-group-input.json",
+    "description": "Alter an existing group of users",
+    "examples": [
+        {
+            "group": "developers",
+            "description": "Product developers",
+            "users": [
+                "bob",
+                "sanya",
+                "alice"
+            ]
+        }
+    ],
+    "type": "object",
+    "required": [
+        "group"
+    ],
+    "properties": {
+        "group": {
+            "title": "Group identifier",
+            "type": "string",
+            "minLength": 1
+        },
+        "description": {
+            "title": "Extended group description",
+            "type":"string"
+        },
+        "users": {
+            "title": "Group members",
+            "type":"array",
+            "items": {
+                "title": "User identifier",
+                "type": "string",
+                "minLength": 1,
+                "uniqueItems": true
+            }
+        }
+    },
+    "$defs": {}
+}

--- a/imageroot/actions/alter-group/validate-input.json
+++ b/imageroot/actions/alter-group/validate-input.json
@@ -25,8 +25,9 @@
             "minLength": 1
         },
         "description": {
-            "title": "Extended group description",
-            "type":"string"
+            "title": "Group description",
+            "type":"string",
+            "maxLength": 256
         },
         "users": {
             "title": "Group members",

--- a/imageroot/actions/alter-user/50alter_user
+++ b/imageroot/actions/alter-user/50alter_user
@@ -36,8 +36,8 @@ if 'password' in request:
 if 'groups' in request:
     alteruser_cmd += ['-g', ','.join(request['groups'])]
 
-if 'full_name' in request:
-    alteruser_cmd += ['-f', request['full_name']]
+if 'display_name' in request:
+    alteruser_cmd += ['-d', request['display_name']]
 
 alteruser_cmd.append(user)
 

--- a/imageroot/actions/alter-user/50alter_user
+++ b/imageroot/actions/alter-user/50alter_user
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import agent
+import json
+import sys
+import subprocess
+
+request = json.load(sys.stdin)
+user = request['user']
+
+alteruser_cmd = ['podman', 'exec', '-i', 'openldap', 'alter-user']
+
+if 'password' in request:
+    alteruser_cmd += ['-p', '-'] # Write password to helper's stdin
+
+if 'groups' in request:
+    alteruser_cmd += ['-g', ','.join(request['groups'])]
+
+if 'full_name' in request:
+    alteruser_cmd += ['-f', request['full_name']]
+
+alteruser_cmd.append(user)
+
+subprocess.run(alteruser_cmd, input=request.get('password'), stdout=sys.stderr, check=True, text=True)

--- a/imageroot/actions/alter-user/validate-input.json
+++ b/imageroot/actions/alter-user/validate-input.json
@@ -1,0 +1,52 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "alter-user input",
+    "$id": "http://schema.nethserver.org/openldap/alter-user-input.json",
+    "description": "Alter an existing user. Only the user identifier attibute is mandatory",
+    "type": "object",
+    "examples": [
+        {
+            "user": "alice",
+            "full_name": "Alice Jordan",
+            "password": "secret",
+            "groups": [
+                "developers","managers"
+            ]
+        }
+    ],
+    "required": [
+        "user"
+    ],
+    "properties": {
+        "user": {
+            "title": "User identifier",
+            "description": "The user must exist",
+            "type": "string",
+            "minLength": 1
+        },
+        "full_name": {
+            "title": "Full name",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 32
+        },
+        "password": {
+            "title": "New password",
+            "description": "If empty, a random password is set",
+            "type": "string",
+            "minLength": 0
+        },
+        "groups": {
+            "title": "Group membership",
+            "description": "Set the user as a member of the given list of groups",
+            "type": "array",
+            "items": {
+                "title": "Group identifier",
+                "type": "string",
+                "uniqueItems": true,
+                "minLength": 1
+            }
+        }
+    },
+    "$defs": {}
+}

--- a/imageroot/actions/alter-user/validate-input.json
+++ b/imageroot/actions/alter-user/validate-input.json
@@ -7,7 +7,7 @@
     "examples": [
         {
             "user": "alice",
-            "full_name": "Alice Jordan",
+            "display_name": "Alice Jordan",
             "password": "secret",
             "groups": [
                 "developers","managers"
@@ -24,17 +24,16 @@
             "type": "string",
             "minLength": 1
         },
-        "full_name": {
+        "display_name": {
             "title": "Full name",
             "type": "string",
-            "minLength": 1,
-            "maxLength": 32
+            "maxLength": 256
         },
         "password": {
             "title": "New password",
             "description": "If empty, a random password is set",
             "type": "string",
-            "minLength": 0
+            "maxLength": 256
         },
         "groups": {
             "title": "Group membership",

--- a/imageroot/actions/remove-group/50remove_group
+++ b/imageroot/actions/remove-group/50remove_group
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import agent
+import json
+import sys
+import subprocess
+
+request = json.load(sys.stdin)
+group = request['group']
+
+removegroup_cmd = ['podman', 'exec', 'openldap', 'remove-group', group]
+subprocess.run(removegroup_cmd, stdout=sys.stderr, check=True, text=True)

--- a/imageroot/actions/remove-group/validate-input.json
+++ b/imageroot/actions/remove-group/validate-input.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "remove-group input",
+    "$id": "http://schema.nethserver.org/openldap/remove-group-input.json",
+    "description": "Remove an existing group of users",
+    "examples": [
+        {
+            "group": "developers"
+        }
+    ],
+    "type": "object",
+    "required": [
+        "group"
+    ],
+    "properties": {
+        "group": {
+            "title": "Group identifier",
+            "type": "string",
+            "minLength": 1
+        }
+    },
+    "$defs": {}
+}

--- a/imageroot/actions/remove-user/50remove_user
+++ b/imageroot/actions/remove-user/50remove_user
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import agent
+import json
+import sys
+import subprocess
+
+request = json.load(sys.stdin)
+user = request['user']
+
+removeuser_cmd = ['podman', 'exec', 'openldap', 'remove-user', user]
+subprocess.run(removeuser_cmd, stdout=sys.stderr, check=True, text=True)

--- a/imageroot/actions/remove-user/validate-input.json
+++ b/imageroot/actions/remove-user/validate-input.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "remove-user input",
+    "$id": "http://schema.nethserver.org/openldap/remove-user-input.json",
+    "description": "Remove an existing user",
+    "examples": [
+        {
+            "user": "alice"
+        }
+    ],
+    "type": "object",
+    "required": [
+        "user"
+    ],
+    "properties": {
+        "user": {
+            "title": "User identifier",
+            "type": "string",
+            "minLength": 1
+        }
+    },
+    "$defs": {}
+}

--- a/imageroot/update-module.d/50restart
+++ b/imageroot/update-module.d/50restart
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+set -e
+
+exec 1>&2
+
+# Restart the service
+systemctl --user restart openldap.service

--- a/server/README.md
+++ b/server/README.md
@@ -4,6 +4,8 @@ This container runs an OpenLDAP server instance. It can be configured as a
 standalone server, or joined to other instances with the same domain
 suffix and multi-provider synchronization.
 
+The LDAP database schema should be compliant with RFC2307.
+
 ## Environment variables
 
 * `LDAP_ADMUSER`, default `admin`. Name of the initial member of `domain admins`

--- a/server/usr/local/bin/add-group
+++ b/server/usr/local/bin/add-group
@@ -53,7 +53,7 @@ if [ -z "${group}" ]; then
     usage_error "Missing GROUP argument"
 fi
 
-if [ "${dflag}" = 1 ]; then
+if [ "${dflag}" = 1 ] && [ -n "${description}" ]; then
     ldif_description=$(echo -n "${description}" | base64 -w 0)
 fi
 
@@ -64,10 +64,8 @@ fi
     printf 'objectClass: posixGroup\n'
     printf 'cn: %s\n' "${group}"
     printf 'gidNumber: %d\n' "${ngid}"
-    if [ -n "${description}" ]; then
+    if [ -n "${ldif_description}" ]; then
         printf 'description:: %s\n' "${ldif_description}"
-    else
-        printf 'description: %s\n' "${group}"
     fi
 
     # Add initial members to the group

--- a/server/usr/local/bin/add-group
+++ b/server/usr/local/bin/add-group
@@ -1,0 +1,82 @@
+#!/bin/ash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+# shellcheck shell=dash disable=SC3001,SC3003,SC3028
+
+usage_error()
+{
+    exec 1>&2
+    [ -n "$1" ] && printf "Error: %s\n" "$1"
+    printf "Usage: %s [OPTIONS] GROUP\n" "$0"
+    printf "    GROUP                    Add/Create a new GROUP of users\n"
+    printf "    OPTIONS\n"
+    printf "      -u user1,user2,...    Comma-separated list of initial group members\n"
+    printf "      -d description        The group description\n"
+    printf "      -g numgid             Set the numeric group identifier\n"
+    exit 2
+}
+
+# XXX default ngid? e.g. max uidNumber + 1
+ngid=$(( 5000 + RANDOM % 10000 ))
+
+while getopts "u:d:g:h" optname ; do
+    case ${optname} in
+        u)  uflag=1 ; users="${OPTARG}" ;;
+        d)  dflag=1 ; description="${OPTARG}" ;;
+        g)  ngid="${OPTARG}" ;;
+        h)  usage_error ;;
+        *)  usage_error ;;
+    esac
+done
+shift $((OPTIND - 1))
+group="$1"
+if [ -z "${group}" ]; then
+    usage_error "Missing GROUP argument"
+fi
+
+if [ "${dflag}" = 1 ]; then
+    ldif_description=$(echo -n "${description}" | base64 -w 0)
+fi
+
+(
+    # Add the new group entry
+    printf 'dn: cn=%s,ou=Groups,%s\n' "${group}" "${LDAP_SUFFIX:?}"
+    printf 'changetype: add\n'
+    printf 'objectClass: posixGroup\n'
+    printf 'cn: %s\n' "${group}"
+    printf 'gidNumber: %d\n' "${ngid}"
+    if [ -n "${description}" ]; then
+        printf 'description:: %s\n' "${ldif_description}"
+    else
+        printf 'description: %s\n' "${group}"
+    fi
+
+    # Add initial members to the group
+    if [ "${uflag}" = 1 ] && [ -n "${users}" ]; then
+        echo "${users}" | tr , $'\n' | while read -r user ; do
+            [ -z "${user}" ] && continue
+            printf 'memberUid: %s\n' "${user}"
+        done
+    fi
+) | ldapmodify -Q
+
+exit $?

--- a/server/usr/local/bin/add-user
+++ b/server/usr/local/bin/add-user
@@ -30,7 +30,7 @@ usage_error()
     printf "    USER                    Add/Create a new USER account\n"
     printf "    OPTIONS\n"
     printf "      -g group1,group2,...  Comma-separated list of groups for initial membership \n"
-    printf "      -f full_name          The full user name\n"
+    printf "      -d display_name       The user display name\n"
     printf "      -p password           Initial password; \"-\" reads from standard input\n"
     printf "      -G numgid             Set the primary group number\n"
     printf "      -U numuid             Set the numeric user identifier\n"
@@ -41,12 +41,12 @@ ngid=1001
 # XXX default nuid? e.g. max uidNumber + 1
 nuid=$(( 1003 + RANDOM % 8996 ))
 
-while getopts "g:f:p:G:U:h" optname ; do
+while getopts "g:d:p:G:U:h" optname ; do
     case ${optname} in
         g)  gflag=1 ; groups="${OPTARG}" ;;
         G)  ngid="${OPTARG}" ;;
         U)  nuid="${OPTARG}" ;;
-        f)  fflag=1 ; full_name="${OPTARG}" ;;
+        d)  dflag=1 ; display_name="${OPTARG}" ;;
         p)  pflag=1 ; password="${OPTARG}" ;;
         h)  usage_error ;;
         *)  usage_error ;;
@@ -68,8 +68,8 @@ if [ "${pflag}" = 1 ]; then
     fi
 fi
 
-if [ "${fflag}" = 1 ]; then
-    ldif_full_name=$(echo -n "${full_name}" | base64 -w 0)
+if [ "${dflag}" = 1 ] && [ -n "${display_name}" ]; then
+    ldif_display_name=$(echo -n "${display_name}" | base64 -w 0)
 fi
 
 (
@@ -82,9 +82,12 @@ fi
     printf 'uidNumber: %d\n' "${nuid}"
     printf 'gidNumber: %d\n' "${ngid}"
     printf 'homeDirectory: /home/%s\n' "${user}"
-    if [ -n "${ldif_full_name}" ]; then
-        printf 'cn:: %s\n' "${ldif_full_name}"
-        printf 'sn:: %s\n' "${ldif_full_name}"
+    if [ -n "${ldif_display_name}" ]; then
+        ldif_cn=$(echo -n "${display_name}" | awk '{print $1}' | base64 -w 0)
+        printf 'cn:: %s\n' "${ldif_cn}"
+        ldif_sn=$(echo -n "${display_name}" | awk '{$1=""; print $0}' | base64 -w 0)
+        printf 'sn:: %s\n' "${ldif_sn}"
+        printf 'displayName:: %s\n' "${ldif_display_name}"
     else
         printf 'cn: %s\n' "${user}"
         printf 'sn: %s\n' "${user}"

--- a/server/usr/local/bin/add-user
+++ b/server/usr/local/bin/add-user
@@ -1,0 +1,112 @@
+#!/bin/ash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+# shellcheck shell=dash disable=SC3001,SC3003,SC3028
+
+usage_error()
+{
+    exec 1>&2
+    [ -n "$1" ] && printf "Error: %s\n" "$1"
+    printf "Usage: %s [OPTIONS] USER\n" "$0"
+    printf "    USER                    Add/Create a new USER account\n"
+    printf "    OPTIONS\n"
+    printf "      -g group1,group2,...  Comma-separated list of groups for initial membership \n"
+    printf "      -f full_name          The full user name\n"
+    printf "      -p password           Initial password; \"-\" reads from standard input\n"
+    printf "      -G numgid             Set the primary group number\n"
+    printf "      -U numuid             Set the numeric user identifier\n"
+    exit 2
+}
+
+ngid=1001
+# XXX default nuid? e.g. max uidNumber + 1
+nuid=$(( 1003 + RANDOM % 8996 ))
+
+while getopts "g:f:p:G:U:h" optname ; do
+    case ${optname} in
+        g)  gflag=1 ; groups="${OPTARG}" ;;
+        G)  ngid="${OPTARG}" ;;
+        U)  nuid="${OPTARG}" ;;
+        f)  fflag=1 ; full_name="${OPTARG}" ;;
+        p)  pflag=1 ; password="${OPTARG}" ;;
+        h)  usage_error ;;
+        *)  usage_error ;;
+    esac
+done
+shift $((OPTIND - 1))
+user=${1}
+if [ -z "${user}" ]; then
+    usage_error "Missing USER argument"
+fi
+
+if [ "${pflag}" = 1 ]; then
+    if [ "${password}" = '-' ]; then
+        echo -n "Enter password: "
+        read -r password # Read password from stdin
+        echo
+    elif [ "${password}" = '' ]; then
+        password=$(dd if=/dev/urandom of=/dev/stdout bs=32 count=1 | base64 -w 0)
+    fi
+fi
+
+if [ "${fflag}" = 1 ]; then
+    ldif_full_name=$(echo -n "${full_name}" | base64 -w 0)
+fi
+
+(
+    # Add the new user entry
+    printf 'dn: uid=%s,ou=People,%s\n' "${user}" "${LDAP_SUFFIX:?}"
+    printf 'changetype: add\n'
+    printf 'objectClass: posixAccount\n'
+    printf 'objectClass: inetOrgPerson\n'
+    printf 'uid: %s\n' "${user}"
+    printf 'uidNumber: %d\n' "${nuid}"
+    printf 'gidNumber: %d\n' "${ngid}"
+    printf 'homeDirectory: /home/%s\n' "${user}"
+    if [ -n "${ldif_full_name}" ]; then
+        printf 'cn:: %s\n' "${ldif_full_name}"
+        printf 'sn:: %s\n' "${ldif_full_name}"
+    else
+        printf 'cn: %s\n' "${user}"
+        printf 'sn: %s\n' "${user}"
+    fi
+
+    # Add group membership attributes to existing groups
+    if [ "${gflag}" = 1 ] && [ -n "${groups}" ]; then
+        echo "${groups}" | tr , $'\n' | LC_ALL=C sort | while read -r group ; do
+            [ -z "${group}" ] && continue
+            printf '\ndn: cn=%s,ou=Groups,%s\n' "${group}" "${LDAP_SUFFIX:?}"
+            printf 'changetype: modify\n'
+            printf 'add: memberUid\n'
+            printf 'memberUid: %s\n' "${user}"
+        done
+    fi
+) | ldapmodify -Q
+
+exit_code=$?
+
+if [ "${pflag}" = 1 ]; then
+    echo -n "${password}" | ldappasswd -Q -T /dev/stdin "uid=${user},ou=People,${LDAP_SUFFIX:?}"
+    exit_code=$((exit_code + $?))
+fi
+
+exit "${exit_code}"

--- a/server/usr/local/bin/alter-group
+++ b/server/usr/local/bin/alter-group
@@ -1,0 +1,75 @@
+#!/bin/ash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+# shellcheck shell=dash disable=SC3001,SC3003,SC3028
+
+usage_error()
+{
+    exec 1>&2
+    [ -n "$1" ] && printf "Error: %s\n" "$1"
+    printf "Usage: %s [OPTIONS] GROUP\n" "$0"
+    printf "    GROUP                    Add/Create a new GROUP of users\n"
+    printf "    OPTIONS\n"
+    printf "      -u user1,user2,...    Comma-separated list of initial group members\n"
+    printf "      -d description        The group description\n"
+    exit 2
+}
+
+while getopts "u:d:h" optname ; do
+    case ${optname} in
+        u)  uflag=1 ; users="${OPTARG}" ;;
+        d)  dflag=1 ; description="${OPTARG}" ;;
+        h)  usage_error ;;
+        *)  usage_error ;;
+    esac
+done
+shift $((OPTIND - 1))
+group="$1"
+if [ -z "${group}" ]; then
+    usage_error "Missing GROUP argument"
+fi
+
+(
+    printf 'dn: cn=%s,ou=Groups,%s\n' "${group}" "${LDAP_SUFFIX:?}"
+    printf 'changetype: modify\n'
+
+    # Set description
+    if [ "${dflag}" = 1 ]; then
+        ldif_description=$(echo -n "${description}" | base64 -w 0)
+        printf 'replace: description\n'
+        printf 'description:: %s\n' "${ldif_description}"
+        printf -- '-\n'
+    fi
+
+    # Replace group members
+    if [ "${uflag}" = 1 ]; then
+        printf 'replace: memberUid\n'
+        echo "${users}" | tr , $'\n' | LC_ALL=C sort | while read -r user ; do
+            [ -z "${user}" ] && continue
+            printf 'memberUid: %s\n' "${user}"
+        done
+        printf -- '-\n'
+    fi
+
+) | tee -a /dev/stderr | ldapmodify -Q
+
+exit $?

--- a/server/usr/local/bin/alter-group
+++ b/server/usr/local/bin/alter-group
@@ -54,9 +54,13 @@ fi
 
     # Set description
     if [ "${dflag}" = 1 ]; then
-        ldif_description=$(echo -n "${description}" | base64 -w 0)
-        printf 'replace: description\n'
-        printf 'description:: %s\n' "${ldif_description}"
+        if [ -n "${description}" ]; then
+            ldif_description=$(echo -n "${description}" | base64 -w 0)
+            printf 'replace: description\n'
+            printf 'description:: %s\n' "${ldif_description}"
+        else
+            printf 'delete: description\n'
+        fi
         printf -- '-\n'
     fi
 

--- a/server/usr/local/bin/alter-group
+++ b/server/usr/local/bin/alter-group
@@ -59,7 +59,7 @@ fi
             printf 'replace: description\n'
             printf 'description:: %s\n' "${ldif_description}"
         else
-            printf 'delete: description\n'
+            printf 'replace: description\n'
         fi
         printf -- '-\n'
     fi

--- a/server/usr/local/bin/alter-user
+++ b/server/usr/local/bin/alter-user
@@ -20,7 +20,7 @@
 # along with NethServer.  If not, see COPYING.
 #
 
-# shellcheck shell=dash disable=SC3001,SC3003,SC3028
+# shellcheck shell=dash disable=SC3001,SC3003,SC3028,SC2181
 
 usage_error()
 {
@@ -30,15 +30,15 @@ usage_error()
     printf "    USER                    Add/Create a new USER account\n"
     printf "    OPTIONS\n"
     printf "      -g group1,group2,...  Set the user as member of the comma-separated list of groups\n"
-    printf "      -f full_name          Set the full user name\n"
+    printf "      -d display_name          Set the user display name\n"
     printf "      -p password           Initial password; \"-\" reads from standard input\n"
     exit 2
 }
 
-while getopts "g:f:p:h" optname ; do
+while getopts "g:d:p:h" optname ; do
     case ${optname} in
         g)  gflag=1 ; groups="${OPTARG}" ;;
-        f)  fflag=1 ; full_name="${OPTARG}" ;;
+        d)  dflag=1 ; display_name="${OPTARG}" ;;
         p)  pflag=1 ; password="${OPTARG}" ;;
         h)  usage_error ;;
         *)  usage_error ;;
@@ -68,16 +68,33 @@ if [ "${pflag}" = 1 ]; then
 fi
 
 (
-    if [ "${fflag}" = 1 ]; then
+    if [ "${dflag}" = 1 ]; then
         # Modify the new user entry
         printf 'dn: uid=%s,ou=People,%s\n' "${user}" "${LDAP_SUFFIX:?}"
         printf 'changetype: modify\n'
-        ldif_full_name=$(echo -n "${full_name}" | base64 -w 0)
-        printf 'replace: cn\n'
-        printf 'cn:: %s\n' "${ldif_full_name}"
-        printf -- '-\n'
-        printf 'replace: sn\n'
-        printf 'sn:: %s\n' "${ldif_full_name}"
+        if [ -n "${display_name}" ]; then
+            ldif_display_name=$(echo -n "${display_name}" | base64 -w 0)
+            printf 'replace: displayName\n'
+            printf 'displayName:: %s\n' "${ldif_display_name}"
+
+            ldif_sn=$(echo -n "${display_name}" | awk '{$1=""; print $0}' | base64 -w 0)
+            printf -- '-\n'
+            printf 'replace: sn\n'
+            printf 'sn:: %s\n' "${ldif_sn}"
+
+            ldif_cn=$(echo -n "${display_name}" | awk '{print $1}' | base64 -w 0)
+            printf -- '-\n'
+            printf 'replace: cn\n'
+            printf 'cn:: %s\n' "${ldif_cn}"
+        else
+            printf 'delete: displayName\n'
+            printf -- '-\n'
+            printf 'replace: sn\n'
+            printf 'sn: %s\n' "${user}"
+            printf -- '-\n'
+            printf 'replace: cn\n'
+            printf 'cn: %s\n' "${user}"
+        fi
     fi
 
     # Change group membership attributes on existing groups

--- a/server/usr/local/bin/alter-user
+++ b/server/usr/local/bin/alter-user
@@ -1,0 +1,103 @@
+#!/bin/ash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+# shellcheck shell=dash disable=SC3001,SC3003,SC3028
+
+usage_error()
+{
+    exec 1>&2
+    [ -n "$1" ] && printf "Error: %s\n" "$1"
+    printf "Usage: %s [OPTIONS] USER\n" "$0"
+    printf "    USER                    Add/Create a new USER account\n"
+    printf "    OPTIONS\n"
+    printf "      -g group1,group2,...  Set the user as member of the comma-separated list of groups\n"
+    printf "      -f full_name          Set the full user name\n"
+    printf "      -p password           Initial password; \"-\" reads from standard input\n"
+    exit 2
+}
+
+while getopts "g:f:p:h" optname ; do
+    case ${optname} in
+        g)  gflag=1 ; groups="${OPTARG}" ;;
+        f)  fflag=1 ; full_name="${OPTARG}" ;;
+        p)  pflag=1 ; password="${OPTARG}" ;;
+        h)  usage_error ;;
+        *)  usage_error ;;
+    esac
+done
+shift $((OPTIND - 1))
+user=${1}
+if [ -z "${user}" ]; then
+    usage_error "Missing USER argument"
+fi
+
+exit_code=0
+
+if [ "${pflag}" = 1 ]; then
+    if [ "${password}" = '-' ]; then
+        echo -n "Enter password: "
+        read -r password # Read password from stdin
+        echo
+    elif [ "${password}" = '' ]; then
+        password=$(dd if=/dev/urandom of=/dev/stdout bs=32 count=1 | base64 -w 0)
+    fi
+    echo -n "${password}" | ldappasswd -Q -T /dev/stdin "uid=${user},ou=People,${LDAP_SUFFIX:?}"
+    exit_code=$((exit_code + $?))
+fi
+
+(
+    if [ "${fflag}" = 1 ]; then
+        # Modify the new user entry
+        printf 'dn: uid=%s,ou=People,%s\n' "${user}" "${LDAP_SUFFIX:?}"
+        printf 'changetype: modify\n'
+        ldif_full_name=$(echo -n "${full_name}" | base64 -w 0)
+        printf 'replace: cn\n'
+        printf 'cn:: %s\n' "${ldif_full_name}"
+        printf -- '-\n'
+        printf 'replace: sn\n'
+        printf 'sn:: %s\n' "${ldif_full_name}"
+    fi
+
+    # Change group membership attributes on existing groups
+    if [ "${gflag}" = 1 ]; then
+        diff -U 0 \
+            <(ldapsearch -LLL -Q "(&(objectClass=posixGroup)(memberUid=${user}))" cn | grep ^cn: | LC_ALL=C sort) \
+            <(echo -n "${groups}" | awk -v RS=, '{ print "cn: " $0 }' | LC_ALL=C sort) \
+            | awk -v "user=${user}" -v "ldap_suffix=${LDAP_SUFFIX:?}" -e '
+        function print_dn_modify_header(group) {
+            printf "\ndn: cn=%s,ou=Groups,%s\n", group, ldap_suffix
+            printf "changetype: modify\n"
+        }
+        /^\+cn: / {
+            print_dn_modify_header($2)
+            print "add: memberUid"
+            print "memberUid: " user
+        }
+        /^-cn: / {
+            print_dn_modify_header($2)
+            print "delete: memberUid"
+            print "memberUid: " user
+        }'
+    fi
+) | ldapmodify -Q
+
+exit $?

--- a/server/usr/local/bin/alter-user
+++ b/server/usr/local/bin/alter-user
@@ -87,7 +87,7 @@ fi
             printf 'replace: cn\n'
             printf 'cn:: %s\n' "${ldif_cn}"
         else
-            printf 'delete: displayName\n'
+            printf 'replace: displayName\n'
             printf -- '-\n'
             printf 'replace: sn\n'
             printf 'sn: %s\n' "${user}"

--- a/server/usr/local/bin/alter-user
+++ b/server/usr/local/bin/alter-user
@@ -50,7 +50,7 @@ if [ -z "${user}" ]; then
     usage_error "Missing USER argument"
 fi
 
-exit_code=0
+errors=0
 
 if [ "${pflag}" = 1 ]; then
     if [ "${password}" = '-' ]; then
@@ -61,7 +61,10 @@ if [ "${pflag}" = 1 ]; then
         password=$(dd if=/dev/urandom of=/dev/stdout bs=32 count=1 | base64 -w 0)
     fi
     echo -n "${password}" | ldappasswd -Q -T /dev/stdin "uid=${user},ou=People,${LDAP_SUFFIX:?}"
-    exit_code=$((exit_code + $?))
+    if [ $? != 0 ]; then
+        errors=$((errors + 1))
+        echo "[ERROR] Password change failed for ${user}" 1>&2
+    fi
 fi
 
 (
@@ -100,4 +103,11 @@ fi
     fi
 ) | ldapmodify -Q
 
-exit $?
+if [ $? != 0 ]; then
+    errors=$((errors + 1))
+    echo "[ERROR] Alter user ${user} failed" 1>&2
+fi
+
+if [ "${errors}" != 0 ]; then
+    exit 1
+fi

--- a/server/usr/local/bin/alter-user
+++ b/server/usr/local/bin/alter-user
@@ -103,17 +103,18 @@ fi
             <(ldapsearch -LLL -Q "(&(objectClass=posixGroup)(memberUid=${user}))" cn | grep ^cn: | LC_ALL=C sort) \
             <(echo -n "${groups}" | awk -v RS=, '{ print "cn: " $0 }' | LC_ALL=C sort) \
             | awk -v "user=${user}" -v "ldap_suffix=${LDAP_SUFFIX:?}" -e '
-        function print_dn_modify_header(group) {
-            printf "\ndn: cn=%s,ou=Groups,%s\n", group, ldap_suffix
+        function print_dn_modify_header() {
+            sub(/^[-+]cn: /, "")
+            printf "\ndn: cn=%s,ou=Groups,%s\n", $0, ldap_suffix
             printf "changetype: modify\n"
         }
         /^\+cn: / {
-            print_dn_modify_header($2)
+            print_dn_modify_header()
             print "add: memberUid"
             print "memberUid: " user
         }
         /^-cn: / {
-            print_dn_modify_header($2)
+            print_dn_modify_header()
             print "delete: memberUid"
             print "memberUid: " user
         }'

--- a/server/usr/local/bin/remove-group
+++ b/server/usr/local/bin/remove-group
@@ -1,0 +1,46 @@
+#!/bin/ash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+# shellcheck shell=dash disable=SC3001,SC3003,SC3028
+
+usage_error()
+{
+    exec 1>&2
+    [ -n "$1" ] && printf "Error: %s\n" "$1"
+    printf "Usage: %s GROUP\n" "$0"
+    printf "    GROUP                   Remove the existing GROUP of users\n"
+    exit 2
+}
+
+while getopts "h" optname ; do
+    case ${optname} in
+        h)  usage_error ;;
+        *)  usage_error ;;
+    esac
+done
+shift $((OPTIND - 1))
+group="$1"
+if [ -z "${group}" ]; then
+    usage_error "Missing GROUP argument"
+fi
+
+ldapdelete -Q "cn=${group},ou=Groups,${LDAP_SUFFIX:?}"

--- a/server/usr/local/bin/remove-user
+++ b/server/usr/local/bin/remove-user
@@ -1,0 +1,64 @@
+#!/bin/ash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+# shellcheck shell=dash disable=SC3001,SC3003,SC3028
+
+usage_error()
+{
+    exec 1>&2
+    [ -n "$1" ] && printf "Error: %s\n" "$1"
+    printf "Usage: %s USER\n" "$0"
+    printf "    USER                    Remove the existing USER account\n"
+    exit 2
+}
+
+while getopts "h" optname ; do
+    case ${optname} in
+        h)  usage_error ;;
+        *)  usage_error ;;
+    esac
+done
+shift $((OPTIND - 1))
+user="$1"
+if [ -z "${user}" ]; then
+    usage_error "Missing USER argument"
+fi
+
+
+(
+    # Delete the user entry
+    printf 'dn: uid=%s,ou=People,%s\n' "${user}" "${LDAP_SUFFIX:?}"
+    printf 'changetype: delete\n'
+
+    # Delete user group membership attributes
+    ldapsearch -Q -LLL "(memberUid=${user})" dn | awk -v "user=${user}" -e '
+    /^dn: / {
+        print ""
+        print $0
+        print "changetype: modify"
+        print "delete: memberUid"
+        print "memberUid:" user
+    }'
+
+) | ldapmodify -Q -c
+
+exit $?

--- a/server/usr/local/lib/templates/config.ldif
+++ b/server/usr/local/lib/templates/config.ldif
@@ -50,6 +50,7 @@ dn: olcDatabase=frontend,cn=config
 objectClass: olcDatabaseConfig
 objectClass: olcFrontendConfig
 olcDatabase: frontend
+olcPasswordHash: {SSHA512}
 
 #
 # Config settings
@@ -92,6 +93,9 @@ olcRootDN: cn=mdbsync,${LDAP_SUFFIX}
 olcRootPW: ${tmpl_rootpass}
 olcDbDirectory:	/var/lib/openldap/openldap-data
 olcDbIndex: objectClass eq
+olcDbIndex: uid pres,eq
+olcDbIndex: cn pres,eq,sub,subinitial
+olcDbIndex: memberUid pres,eq
 olcAccess: to attrs=userPassword by dn.base="
  gidNumber=101+uidNumber=100,cn=peercred,cn=external,cn=aut
  h" manage by set="[cn=domain admins,ou=Groups,${LDAP_SUFFIX}

--- a/server/usr/local/lib/templates/mdb0.ldif
+++ b/server/usr/local/lib/templates/mdb0.ldif
@@ -42,7 +42,7 @@ uidNumber: 1001
 gidNumber: 1001
 uid: ${LDAP_ADMUSER}
 userPassword: ${tmpl_admpwh}
-gecos: ${LDAP_ADMUSER}
+displayName: Builtin administrator user
 cn: ${LDAP_ADMUSER}
 sn: ${LDAP_ADMUSER}
 objectClass: posixAccount

--- a/server/usr/local/lib/templates/mdb0.ldif
+++ b/server/usr/local/lib/templates/mdb0.ldif
@@ -24,15 +24,17 @@ objectClass: simpleSecurityObject
 cn: ${LDAP_SVCUSER}
 userPassword: ${LDAP_SVCPASS}
 
-dn: cn=locals,ou=Groups,${LDAP_SUFFIX}
+dn: cn=locals,${LDAP_SUFFIX}
 gidNumber: 1001
 cn: locals
+description: Default users primary group
 objectClass: posixGroup
 
 dn: cn=domain admins,ou=Groups,${LDAP_SUFFIX}
 gidNumber: 1002
 objectClass: posixGroup
 cn: domain admins
+description: Domain Administrators
 memberUid: ${LDAP_ADMUSER}
 
 dn: uid=${LDAP_ADMUSER},ou=People,${LDAP_SUFFIX}

--- a/tests/10__configure_domain.robot
+++ b/tests/10__configure_domain.robot
@@ -14,10 +14,10 @@ Configure the domain
     ...    api-cli run module/${MID1}/configure-module --data '{"provision":"new-domain","domain":"${DOMAIN}","admuser":"${admuser}","admpass":"${admpass}"}'
     ...    return_rc=True  return_stdout=True  return_stderr=True
     Should Be Equal As Integers    ${rc}  0
-    ${surl} =     Get server url    ${MID1}
-    Set Suite Variable    ${surl}    ${surl}
-    RootDSE is correct    ${surl}
+    ${val} =     Get server url    ${MID1}
+    Set Global Variable    ${SURL}    ${val}
+    RootDSE is correct    ${SURL}
 
 The server is reachable after restart
     Execute Command    systemctl stop user@$(id -u ${MID1}) ; systemctl start user@$(id -u ${MID1})
-    Wait Until Keyword Succeeds    10s    1s    RootDSE is correct    ${surl}
+    Wait Until Keyword Succeeds    10s    1s    RootDSE is correct    ${SURL}

--- a/tests/20__acls.robot
+++ b/tests/20__acls.robot
@@ -10,37 +10,37 @@ ${DOMSUFFIX}    dc\=x,dc\=y
 *** Keywords ***
 Setup acl suite vars
     ${val} =     Get server url    ${MID1}
-    Set Suite Variable    ${surl}    ${val}
+    Set Suite Variable    ${SURL}    ${val}
 
 *** Test Cases ***
 Bad user logon fails
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapwhoami -H ${surl} -x -D 'uid\=baduser,${DOMSUFFIX}' -w 'badpass'
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapwhoami -H ${SURL} -x -D 'uid\=baduser,${DOMSUFFIX}' -w 'badpass'
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
     Should Be Equal As Integers    ${rc}    49
     Should Be Equal    ${out}    ${EMPTY}
     Should Contain    ${err}    Invalid credentials
 
 Admin bind succeedes
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapwhoami -H ${surl} -x -D 'uid\=${admuser},ou=People,${DOMSUFFIX}' -w '${admpass}'
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapwhoami -H ${SURL} -x -D 'uid\=${admuser},ou=People,${DOMSUFFIX}' -w '${admpass}'
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
     Should Be Equal As Integers    ${rc}    0
     Should Be Equal    ${out}    dn:uid\=${admuser},ou=People,${DOMSUFFIX}
 
 Admin read access is configured
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapsearch -H ${surl} -LLL -x -D 'uid\=${admuser},ou=People,${DOMSUFFIX}' -w '${admpass}' -b ${DOMSUFFIX} userPassword\=* userPassword uid
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapsearch -H ${SURL} -LLL -x -D 'uid\=${admuser},ou=People,${DOMSUFFIX}' -w '${admpass}' -b ${DOMSUFFIX} userPassword\=* userPassword uid
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${out}    userPassword:
     Should Contain    ${out}    uid:
 
 Anonymous bind succeedes
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapwhoami -H ${surl} -x -D '' -w ''
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapwhoami -H ${SURL} -x -D '' -w ''
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
     Should Be Equal As Integers    ${rc}    0
     Should Be Equal    ${out}    anonymous
 
 Anonymous read access is configured
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapsearch -H ${surl} -LLL -x -D '' -w '' -b ${DOMSUFFIX} uid=admin userPassword uid
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapsearch -H ${SURL} -LLL -x -D '' -w '' -b ${DOMSUFFIX} uid=admin userPassword uid
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
     Should Be Equal As Integers    ${rc}    0
     Should Not Contain    ${out}    userPassword:
@@ -48,14 +48,14 @@ Anonymous read access is configured
 
 Ldapservice bind succeedes
     ${ldap_svcdn}    ${ldap_svcpass} =     Get ldapservice credentials    ${mid1}
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapwhoami -H ${surl} -x -D '${ldap_svcdn}' -w '${ldap_svcpass}'
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapwhoami -H ${SURL} -x -D '${ldap_svcdn}' -w '${ldap_svcpass}'
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
     Should Be Equal As Integers    ${rc}    0
     Should Be Equal    ${out}    dn:${ldap_svcdn}
 
 Ldapservice read access is configured
     ${ldap_svcdn}    ${ldap_svcpass} =     Get ldapservice credentials    ${mid1}
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapsearch -H ${surl} -LLL -x -D '${ldap_svcdn}' -w '${ldap_svcpass}' -b ${DOMSUFFIX} uid=admin userPassword uid
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapsearch -H ${SURL} -LLL -x -D '${ldap_svcdn}' -w '${ldap_svcpass}' -b ${DOMSUFFIX} uid=admin userPassword uid
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
     Should Be Equal As Integers    ${rc}    0
     Should Not Contain    ${out}    userPassword:
@@ -63,10 +63,10 @@ Ldapservice read access is configured
 
 Configuration database is not readable
     ${ldap_svcdn}    ${ldap_svcpass} =     Get ldapservice credentials    ${mid1}
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapsearch -H ${surl} -b cn\=config -s base -x -D '${ldap_svcdn}' -w '${ldap_svcpass}'
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapsearch -H ${SURL} -b cn\=config -s base -x -D '${ldap_svcdn}' -w '${ldap_svcpass}'
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
     Should Be Equal As Integers    ${rc}    32
 
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapsearch -H ${surl} -b cn\=config -s base -x -D '' -w ''
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapsearch -H ${SURL} -b cn\=config -s base -x -D '' -w ''
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
     Should Be Equal As Integers    ${rc}    32

--- a/tests/30__api_groups_management.robot
+++ b/tests/30__api_groups_management.robot
@@ -41,6 +41,14 @@ Alter group group1
     Should Contain      ${out}    memberUid: u2
     Should Contain      ${out}    chdesc
 
+Remove group1 description
+    Run task    module/${MID1}/alter-group    {"group":"group1","description":""}
+
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ldapclient ldapsearch -LLL -H ${SURL} -x -D 'uid\=${admuser},ou=People,${DOMSUFFIX}' -w '${admpass}' -b '${DOMSUFFIX}' cn=group1
+    ...    return_stderr=${TRUE}    return_rc=${TRUE}
+    Should Be Equal As Integers     ${rc}    0
+    Should Not Contain    ${out}    description:
+
 Alter non-existing group
     Run task    module/${MID1}/alter-group    {"group":"bad-user","description":"Does not matter","users":[]}
     ...    rc_expected=1

--- a/tests/30__api_groups_management.robot
+++ b/tests/30__api_groups_management.robot
@@ -1,0 +1,53 @@
+*** Settings ***
+Resource        keywords.resource
+
+Suite Setup     Add test users
+Suite Teardown  Remove test users
+
+*** Keywords ***
+Add test users
+    Run task    module/${MID1}/add-user    {"user":"u1","groups":[],"display_name":"User One"}
+    Run task    module/${MID1}/add-user    {"user":"u2","groups":[],"display_name":"User Two"}
+
+Remove test users
+    Run task    module/${MID1}/remove-user    {"user":"u1"}
+    Run task    module/${MID1}/remove-user    {"user":"u2"}
+
+*** Test Cases ***
+Add group group1
+    Run task    module/${MID1}/add-group    {"group":"group1","description":"First group","users":["u1"]}
+
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch cn=group1
+    ...    return_stderr=${TRUE}    return_rc=${TRUE}
+    Should Be Equal As Integers     ${rc}    0
+    Should Contain      ${out}      group1
+    Should Contain      ${out}      First group
+    Should Contain      ${out}      memberUid: u1
+    Should Not Contain  ${out}      memberUid: u2
+
+Group already exists
+    Run task    module/${MID1}/add-group    {"group":"group1","description":"First group","users":["u1"]}
+    ...    rc_expected=2
+
+Alter group group1
+    Run task    module/${MID1}/alter-group    {"group":"group1","description":"chdesc","users":["u2"]}
+
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch cn=group1
+    ...    return_stderr=${TRUE}    return_rc=${TRUE}
+    Should Be Equal As Integers   ${rc}    0
+    Should Contain      ${out}    group1
+    Should Not Contain  ${out}    First group
+    Should Not Contain  ${out}    memberUid: u1
+    Should Contain      ${out}    memberUid: u2    
+    Should Contain      ${out}    Y2hkZXNjCg\=\=    # Base64 encoding of "chdesc"
+
+Alter non-existing group
+    Run task    module/${MID1}/alter-group    {"group":"bad-user","description":"Does not matter","users":[]}
+    ...    rc_expected=1
+
+Remove group group1
+    Run task    module/${MID1}/remove-group    {"group":"group1"}
+
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch cn=group1
+    ...    return_stderr=${TRUE}    return_rc=${TRUE}
+    Should Not Be Equal As Integers    ${rc}    0

--- a/tests/30__api_groups_management.robot
+++ b/tests/30__api_groups_management.robot
@@ -17,7 +17,7 @@ Remove test users
 Add group group1
     Run task    module/${MID1}/add-group    {"group":"group1","description":"First group","users":["u1"]}
 
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch cn=group1
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ldapclient ldapsearch -LLL -H ${SURL} -x -D 'uid\=${admuser},ou=People,${DOMSUFFIX}' -w '${admpass}' -b '${DOMSUFFIX}' cn=group1
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
     Should Be Equal As Integers     ${rc}    0
     Should Contain      ${out}      group1
@@ -32,14 +32,14 @@ Group already exists
 Alter group group1
     Run task    module/${MID1}/alter-group    {"group":"group1","description":"chdesc","users":["u2"]}
 
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch cn=group1
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ldapclient ldapsearch -LLL -H ${SURL} -x -D 'uid\=${admuser},ou=People,${DOMSUFFIX}' -w '${admpass}' -b '${DOMSUFFIX}' cn=group1
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
     Should Be Equal As Integers   ${rc}    0
     Should Contain      ${out}    group1
     Should Not Contain  ${out}    First group
     Should Not Contain  ${out}    memberUid: u1
-    Should Contain      ${out}    memberUid: u2    
-    Should Contain      ${out}    Y2hkZXNjCg\=\=    # Base64 encoding of "chdesc"
+    Should Contain      ${out}    memberUid: u2
+    Should Contain      ${out}    chdesc
 
 Alter non-existing group
     Run task    module/${MID1}/alter-group    {"group":"bad-user","description":"Does not matter","users":[]}
@@ -48,6 +48,6 @@ Alter non-existing group
 Remove group group1
     Run task    module/${MID1}/remove-group    {"group":"group1"}
 
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch cn=group1
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ldapclient ldapsearch -LLL -H ${SURL} -x -D 'uid\=${admuser},ou=People,${DOMSUFFIX}' -w '${admpass}' -b '${DOMSUFFIX}' cn=group1
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
-    Should Not Be Equal As Integers    ${rc}    0
+    Should Not Contain    ${out}    numEntries:

--- a/tests/30__api_users_management.robot
+++ b/tests/30__api_users_management.robot
@@ -17,13 +17,13 @@ Remove test groups
 Add user first.user
     Run task    module/${MID1}/add-user    {"user":"first.user","display_name":"First User","locked":false,"groups":["g1"]}
 
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch uid=first.user
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ldapclient ldapsearch -LLL -H ${SURL} -x -D 'uid\=${admuser},ou=People,${DOMSUFFIX}' -w '${admpass}' -b '${DOMSUFFIX}' uid=first.user
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${out}    first.user
     Should Contain    ${out}    First User
 
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch cn=g1
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ldapclient ldapsearch -LLL -H ${SURL} -x -D 'uid\=${admuser},ou=People,${DOMSUFFIX}' -w '${admpass}' -b '${DOMSUFFIX}' cn=g1
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${out}    memberUid: first.user
@@ -35,7 +35,7 @@ User already exists failure
 Alter user first.user
     Run task    module/${MID1}/alter-user    {"user":"first.user","display_name":"Changed full name","locked":true,"groups":["g2"]}
 
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch uid=first.user
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ldapclient ldapsearch -LLL -H ${SURL} -x -D 'uid\=${admuser},ou=People,${DOMSUFFIX}' -w '${admpass}' -b '${DOMSUFFIX}' uid=first.user
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${out}    first.user
@@ -43,12 +43,12 @@ Alter user first.user
     Should Contain    ${out}    Changed full name
 
 
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch cn=g1
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ldapclient ldapsearch -LLL -H ${SURL} -x -D 'uid\=${admuser},ou=People,${DOMSUFFIX}' -w '${admpass}' -b '${DOMSUFFIX}' cn=g1
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
     Should Be Equal As Integers    ${rc}    0
     Should Not Contain    ${out}    memberUid: first.user
 
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch cn=g2
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ldapclient ldapsearch -LLL -H ${SURL} -x -D 'uid\=${admuser},ou=People,${DOMSUFFIX}' -w '${admpass}' -b '${DOMSUFFIX}' cn=g2
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${out}    memberUid: first.user
@@ -60,6 +60,6 @@ Alter non-existing user
 Remove user first.user
     Run task    module/${MID1}/remove-user    {"user":"first.user"}
 
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch uid=first.user
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ldapclient ldapsearch -LLL -H ${SURL} -x -D 'uid\=${admuser},ou=People,${DOMSUFFIX}' -w '${admpass}' -b '${DOMSUFFIX}' uid=first.user
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
-    Should Not Be Equal As Integers    ${rc}    0
+    Should Not Contain    ${out}    numEntries:

--- a/tests/30__api_users_management.robot
+++ b/tests/30__api_users_management.robot
@@ -53,6 +53,15 @@ Alter user first.user
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${out}    memberUid: first.user
 
+Remove first.user display name
+    Run task    module/${MID1}/alter-user    {"user":"first.user","display_name":""}
+
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ldapclient ldapsearch -LLL -H ${SURL} -x -D 'uid\=${admuser},ou=People,${DOMSUFFIX}' -w '${admpass}' -b '${DOMSUFFIX}' uid=first.user
+    ...    return_stderr=${TRUE}    return_rc=${TRUE}
+    Should Be Equal As Integers    ${rc}    0
+    Should Not Contain    ${out}    displayName:
+
+
 Alter non-existing user
     Run task    module/${MID1}/alter-user    {"user":"bad-user","display_name":"First User","locked":false,"groups":["g1"]}
     ...    rc_expected=1

--- a/tests/30__api_users_management.robot
+++ b/tests/30__api_users_management.robot
@@ -1,0 +1,65 @@
+*** Settings ***
+Resource        keywords.resource
+
+Suite Setup     Add test groups
+Suite Teardown  Remove test groups
+
+*** Keywords ***
+Add test groups
+    Run task    module/${MID1}/add-group    {"group":"g1","users":[]}
+    Run task    module/${MID1}/add-group    {"group":"g2","users":[]}
+
+Remove test groups
+    Run task    module/${MID1}/remove-group    {"group":"g1"}
+    Run task    module/${MID1}/remove-group    {"group":"g2"}
+
+*** Test Cases ***
+Add user first.user
+    Run task    module/${MID1}/add-user    {"user":"first.user","display_name":"First User","locked":false,"groups":["g1"]}
+
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch uid=first.user
+    ...    return_stderr=${TRUE}    return_rc=${TRUE}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${out}    first.user
+    Should Contain    ${out}    First User
+
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch cn=g1
+    ...    return_stderr=${TRUE}    return_rc=${TRUE}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${out}    memberUid: first.user
+
+User already exists failure
+    Run task    module/${MID1}/add-user    {"user":"first.user","display_name":"First User","locked":false,"groups":["g1"]}
+    ...    rc_expected=2
+
+Alter user first.user
+    Run task    module/${MID1}/alter-user    {"user":"first.user","display_name":"Changed full name","locked":true,"groups":["g2"]}
+
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch uid=first.user
+    ...    return_stderr=${TRUE}    return_rc=${TRUE}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${out}    first.user
+    Should Not Contain    ${out}    First User
+    Should Contain    ${out}    Changed full name
+
+
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch cn=g1
+    ...    return_stderr=${TRUE}    return_rc=${TRUE}
+    Should Be Equal As Integers    ${rc}    0
+    Should Not Contain    ${out}    memberUid: first.user
+
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch cn=g2
+    ...    return_stderr=${TRUE}    return_rc=${TRUE}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${out}    memberUid: first.user
+
+Alter non-existing user
+    Run task    module/${MID1}/alter-user    {"user":"bad-user","display_name":"First User","locked":false,"groups":["g1"]}
+    ...    rc_expected=1
+
+Remove user first.user
+    Run task    module/${MID1}/remove-user    {"user":"first.user"}
+
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec ${MID1} ldapsearch uid=first.user
+    ...    return_stderr=${TRUE}    return_rc=${TRUE}
+    Should Not Be Equal As Integers    ${rc}    0

--- a/tests/30__join_server.robot
+++ b/tests/30__join_server.robot
@@ -14,8 +14,8 @@ Join domain
     ...    return_rc=True  return_stdout=True  return_stderr=True
     Should Be Equal As Integers    ${rc}  0
     ${val} =     Get server url    ${MID2}
-    Set Suite Variable    ${surl}    ${val}
-    RootDSE is correct    ${surl}
+    Set Suite Variable    ${SURL}    ${val}
+    RootDSE is correct    ${SURL}
 
 Changes are propagated to them
     [Tags]    unstable

--- a/tests/api.resource
+++ b/tests/api.resource
@@ -1,0 +1,14 @@
+*** Settings ***
+Library    SSHLibrary
+
+*** Keywords ***
+Run task
+    [Arguments]    ${action}    ${input}    ${decode_json}=${TRUE}    ${rc_expected}=0
+    ${stdout}    ${stderr}    ${rc} =     Execute Command    api-cli run ${action} --data '${input}'    return_stdout=True    return_stderr=True    return_rc=True
+    Should Be Equal As Integers    ${rc_expected}    ${rc}    Run task ${action} failed!${\n}${stderr}
+    IF    ${decode_json} and len($stdout) > 0
+        ${response} =    Evaluate    json.loads('''${stdout}''')    modules=json
+    ELSE
+        ${response} =    Set Variable    ${stdout}
+    END
+    [Return]    ${response}

--- a/tests/keywords.resource
+++ b/tests/keywords.resource
@@ -1,11 +1,15 @@
 *** Settings ***
 Library     SSHLibrary
-Variables  vars.py
+Resource    api.resource
+Variables   vars.py
 
 *** Variables ***
 ${IMAGE_URL}    http://ghrc.io/nethserver/openldap:latest
 ${DOMSUFFIX}    dc\=x,dc\=y
-
+${MID1}         unknown00
+${DOMSUFFIX}    dc\=x,dc\=y
+${DOMAIN}       dom.test
+${SURL}         ldap://
 
 *** Keywords ***
 Create a module instance

--- a/tests/keywords.resource
+++ b/tests/keywords.resource
@@ -37,8 +37,8 @@ Get ldapservice credentials
     [Return]    ${srv.bind_dn}    ${srv.bind_password}
 
 RootDSE is correct
-    [Arguments]    ${surl}
-    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapsearch -LLL -x -D '' -w '' -H ${surl} -b '' -s base namingContexts
+    [Arguments]    ${SURL}
+    ${out}  ${err}  ${rc} =    Execute Command    podman exec -i ldapclient ldapsearch -LLL -x -D '' -w '' -H ${SURL} -b '' -s base namingContexts
     ...    return_stderr=${TRUE}    return_rc=${TRUE}
     Should Contain    ${out}    namingContexts: ${DOMSUFFIX}    ignore_case=${TRUE}
 


### PR DESCRIPTION
Implement users and group management APIs for a LDAP RFC2307 DB schema.

## Adding

- add-user, alter-user, remove-user 
- add-group, alter-group, remove-group

User attributes:
- password, 
- full name (displayName),
- ~~locked state~~,
- group membership,
- uidNumber, gidNumber (randomly assigned)

Group attributes:
- description,
- members,
- gidNumber

## Testing

Install the module from `users-api` branch

    api-cli run add-internal-provider --data '{"image":"ghcr.io/nethserver/openldap:users-api","node":1}'
    api-cli run module/openldap1/configure-module --data '{"provision":"new-domain","admuser":"admin","admpass":"secret","domain":"dom.test"}'

## Postponed
* uidNumber and gidNumber are assigned randomly: the allocation procedure must be improved
* Domain password policy management
* Add "password does not expire" user flag
* Account locked state

## See also

https://github.com/NethServer/ns8-core/pull/241 for the read side.
