### PR TITLE
Implement import-module for ns7 migration

### DIFF
--- a/imageroot/actions/configure-module/50start_provisioning
+++ b/imageroot/actions/configure-module/50start_provisioning
@@ -39,6 +39,7 @@ provision_type = request['provision']
 
 
 podman_cmd = ["podman", "run", "--rm",
+    "--replace", "--name=start_provisioning",
     "--log-driver=none",
     "--network=host",
     "--env=LDAP_*",

--- a/imageroot/actions/import-module/50import_environment
+++ b/imageroot/actions/import-module/50import_environment
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+import json
+import agent
+import os
+
+ienv = agent.read_envfile("import.env")
+server_id = int(os.environ['MODULE_ID'].removeprefix("openldap"))
+node_id = os.environ['NODE_ID']
+
+with agent.redis_connect() as rdb:
+    # Retrieve the node VPN IP address to bind on it
+    ip_address = rdb.hget(f'node/{node_id}/vpn', 'ip_address')
+    agent.assert_exp(ip_address is not None)
+
+for evar in [
+        'LDAP_SVCUSER',
+        'LDAP_SVCPASS',
+        'LDAP_DOMAIN',
+        'LDAP_SUFFIX',
+    ]:
+    agent.set_env(evar, ienv[evar])
+
+ldapenv = {
+    'LDAP_SERVERID': str(server_id),
+    'LDAP_PORT': os.environ['TCP_PORT'],
+    'LDAP_IPADDR': ip_address,
+    'LDAP_LOGTAG': os.environ['MODULE_ID'],
+}
+
+for lvar in ldapenv:
+    agent.set_env(lvar, ldapenv[lvar])
+
+agent.dump_env()

--- a/imageroot/actions/import-module/55new_domain
+++ b/imageroot/actions/import-module/55new_domain
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+exec 1>&2
+set -e
+
+echo "Provision a new domain with imported DB dump:"
+podman run \
+    --env=LDAP_\* \
+    --log-driver=none \
+    --replace --name=new_domain --rm \
+    --volume=data:/var/lib/openldap:U,Z \
+    --network=host \
+    "${OPENLDAP_SERVER_IMAGE}" /usr/local/bin/new-domain

--- a/imageroot/actions/import-module/70start_server
+++ b/imageroot/actions/import-module/70start_server
@@ -1,0 +1,1 @@
+../configure-module/70start_server

--- a/imageroot/actions/import-module/80advertise_service
+++ b/imageroot/actions/import-module/80advertise_service
@@ -1,0 +1,1 @@
+../configure-module/80advertise_service

--- a/imageroot/actions/leave-domain/50leave_domain
+++ b/imageroot/actions/leave-domain/50leave_domain
@@ -24,6 +24,7 @@ exec 1>&2
 set -e
 
 podman run --rm \
+    --replace --name=leave_domain \
     --log-driver=none \
     --network=host \
     --env=LDAP_\* \

--- a/imageroot/actions/restore-module/60load_dumpfiles
+++ b/imageroot/actions/restore-module/60load_dumpfiles
@@ -12,10 +12,8 @@ echo "Resume OpenLDAP server state:"
 podman run \
     --env=LDAP_\* \
     --log-driver=none \
-    --replace --name=resume_state --rm \
+    --replace --name=load_dumpfiles --rm \
     --volume=data:/var/lib/openldap:Z \
     --network=host \
     "${OPENLDAP_SERVER_IMAGE}" /usr/local/bin/load-dumpfiles
 
-# Enable and start the LDAP server
-systemctl --user enable --now openldap.service

--- a/imageroot/actions/restore-module/60resume_state
+++ b/imageroot/actions/restore-module/60resume_state
@@ -11,9 +11,9 @@ set -e
 echo "Resume OpenLDAP server state:"
 podman run \
     --env=LDAP_\* \
-    --name=resume_state --rm \
+    --log-driver=none \
+    --replace --name=resume_state --rm \
     --volume=data:/var/lib/openldap:Z \
-    --volume=/dev/log:/dev/log \
     --network=host \
     "${OPENLDAP_SERVER_IMAGE}" /usr/local/bin/load-dumpfiles
 

--- a/imageroot/actions/restore-module/70start_server
+++ b/imageroot/actions/restore-module/70start_server
@@ -1,0 +1,1 @@
+../configure-module/70start_server

--- a/imageroot/systemd/user/openldap.service
+++ b/imageroot/systemd/user/openldap.service
@@ -18,6 +18,11 @@ ExecStart=/usr/bin/podman run \
     --volume=/dev/log:/dev/log \
     --network=host \
     ${OPENLDAP_SERVER_IMAGE}
+
+# Wait until TCP port is ready
+ExecStartPost=/usr/bin/sleep 1
+ExecStartPost=/usr/bin/bash -c "while ! exec 3<>/dev/tcp/${LDAP_IPADDR}/${LDAP_PORT}; do sleep 5 ; done"
+
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/openldap.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/openldap.ctr-id
 PIDFile=%t/openldap.pid

--- a/server/README.md
+++ b/server/README.md
@@ -49,6 +49,13 @@ The container runs as `ldap` user. All data is written under
 `/var/lib/openldap`: mount it as a persistent volume to preserve the
 database over the time, after executing different commands.
 
+The initial volume must be empty to receive default volume contents from
+the container image, and provision the LDAP tree with default users and
+groups.
+
+As alternative, mount a volume containing the LDAP DB dump file
+`dump-mdb0.ldif`: the initial LDAP tree is then loaded from it.
+
 ## Commands
 
 The container entrypoint starts `slapd` if no arguments are specified.
@@ -57,7 +64,8 @@ Otherwise the arguments are assumed to be a command and are exec()'d.
 Commands to run when slapd is stopped:
 
 * `new-domain`: initializes a new domain database with single server
-  configuration.
+  configuration. If the `dump-mdb0.ldif` file exists, loads it otherwise
+  generate users and groups from the internal .ldif template file.
 * `join-domain SRVURLs`: contact other servers at _SRVURLs_ and add this
   server to the existing domain.
 * `leave-domain`: contact other (known) domain servers and tell them to

--- a/server/usr/local/bin/join-domain
+++ b/server/usr/local/bin/join-domain
@@ -80,7 +80,7 @@ else # join-other
 fi
 
 # Copy the configuration database 
-ldapsearch -LLL -x -D cn=config -w "${tmpl_rootpass}" -H "${joinurls}" -b cn=config '*' | slapadd -n 0 -F conf.d
+ldapsearch -LLL -x -D cn=config -w "${tmpl_rootpass}" -H "${joinurls}" -b cn=config '*' | slapadd -v -n 0 -F conf.d
 
 # Ensure the configuration is correct
 slaptest -u -v -F conf.d

--- a/server/usr/local/bin/join-domain
+++ b/server/usr/local/bin/join-domain
@@ -26,7 +26,8 @@ set -e # exit on error
 
 joinurls=${1:?missing joinurls argument}
 
-if ldapwhoami >/dev/null 2>&1 ; then
+# Safety check: slapd must be stopped
+if pgrep -x slapd >/dev/null 2>&1; then
     echo "[ERROR] slapd must be stopped before running $0" 1>&2
     exit 1
 fi

--- a/server/usr/local/bin/leave-domain
+++ b/server/usr/local/bin/leave-domain
@@ -24,7 +24,8 @@
 
 set -e # exit on error
 
-if ldapwhoami >/dev/null 2>&1 ; then
+# Safety check: slapd must be stopped
+if pgrep -x slapd >/dev/null 2>&1; then
     echo "[ERROR] slapd must be stopped before running $0" 1>&2
     exit 1
 fi

--- a/server/usr/local/bin/load-dumpfiles
+++ b/server/usr/local/bin/load-dumpfiles
@@ -10,8 +10,8 @@
 set -e # exit on error
 
 # Safety check: slapd must be stopped
-if [ -f run/slapd.pid ] && grep -q slapd "/proc/$(cat run/slapd.pid)/cmdline"; then
-    echo "Could not load dump files whilst slapd is running!" 1>&2
+if pgrep -x slapd >/dev/null 2>&1; then
+    echo "[ERROR] slapd must be stopped before running $0" 1>&2
     exit 1
 fi
 
@@ -31,7 +31,7 @@ mkdir -m 0750 -v conf.d
 mkdir -m 0700 -v openldap-data
 
 echo "Loading config dump..."
-cat dump-config.ldif | slapadd -v -F conf.d -b cn=config
+slapadd -v -F conf.d -b cn=config -l dump-config.ldif
 
 # Reset the server ID attribute and remove any syncrepl configuration
 slapmodify -v -F conf.d -b cn=config <<EOF

--- a/server/usr/local/bin/new-domain
+++ b/server/usr/local/bin/new-domain
@@ -38,13 +38,18 @@ tmpl_rootpass="$(slappasswd -g -u)$(slappasswd -g -u)$(slappasswd -g -u)"
 
 export tmpl_admpwh tmpl_rootpass
 
-mkdir -m 0750 conf.d # Fail if already configured!
-echo "Generating new domain ${LDAP_DOMAIN} configuration..."
+# Erase config and DB contents
+rm -rfv openldap-data conf.d
+
+# Re-create dirs
+mkdir -m 0750 -v conf.d
+mkdir -m 0700 -v openldap-data
+
+echo "Generating configuration for new domain ${LDAP_DOMAIN}..."
 slapadd -v -w -S "${LDAP_SERVERID}" -n 0 -F conf.d < <(envsubst <"${TEMPLATES_DIR}/config.ldif" | tee dump-config.ldif)
 
 if [ -f dump-mdb0.ldif ]; then
     echo "Restoring ${LDAP_SUFFIX} database for ${LDAP_DOMAIN}"
-    mkdir -m 0700 -vp openldap-data
     slapadd -v -F conf.d -b "${LDAP_SUFFIX}" -l dump-mdb0.ldif
 else
     echo "Creating ${LDAP_SUFFIX} database for ${LDAP_DOMAIN}"

--- a/server/usr/local/bin/new-domain
+++ b/server/usr/local/bin/new-domain
@@ -39,7 +39,15 @@ tmpl_rootpass="$(slappasswd -g -u)$(slappasswd -g -u)$(slappasswd -g -u)"
 export tmpl_admpwh tmpl_rootpass
 
 mkdir -m 0750 conf.d # Fail if already configured!
-echo "Creating ${LDAP_SUFFIX} database for ${LDAP_DOMAIN}"
+echo "Generating new domain ${LDAP_DOMAIN} configuration..."
 slapadd -v -w -S "${LDAP_SERVERID}" -n 0 -F conf.d < <(envsubst <"${TEMPLATES_DIR}/config.ldif" | tee dump-config.ldif)
-slapadd -v -w -S "${LDAP_SERVERID}" -b "${LDAP_SUFFIX}" -F conf.d < <(envsubst <"${TEMPLATES_DIR}/mdb0.ldif" | tee dump-mdb0.ldif)
+
+if [ -f dump-mdb0.ldif ]; then
+    echo "Restoring ${LDAP_SUFFIX} database for ${LDAP_DOMAIN}"
+    mkdir -m 0700 -vp openldap-data
+    slapadd -v -F conf.d -b "${LDAP_SUFFIX}" -l dump-mdb0.ldif
+else
+    echo "Creating ${LDAP_SUFFIX} database for ${LDAP_DOMAIN}"
+    slapadd -v -w -S "${LDAP_SERVERID}" -b "${LDAP_SUFFIX}" -F conf.d < <(envsubst <"${TEMPLATES_DIR}/mdb0.ldif" | tee dump-mdb0.ldif)
+fi
 slaptest -v -F conf.d

--- a/server/usr/local/bin/new-domain
+++ b/server/usr/local/bin/new-domain
@@ -33,6 +33,6 @@ export tmpl_admpwh tmpl_rootpass
 
 mkdir -m 0750 conf.d # Fail if already configured!
 echo "Creating ${LDAP_SUFFIX} database for ${LDAP_DOMAIN}"
-slapadd -w -S "${LDAP_SERVERID}" -n 0 -F conf.d < <(envsubst <"${TEMPLATES_DIR}/config.ldif" | tee dump-config.ldif)
-slapadd -w -S "${LDAP_SERVERID}" -b "${LDAP_SUFFIX}" -F conf.d < <(envsubst <"${TEMPLATES_DIR}/mdb0.ldif" | tee dump-mdb0.ldif)
+slapadd -v -w -S "${LDAP_SERVERID}" -n 0 -F conf.d < <(envsubst <"${TEMPLATES_DIR}/config.ldif" | tee dump-config.ldif)
+slapadd -v -w -S "${LDAP_SERVERID}" -b "${LDAP_SUFFIX}" -F conf.d < <(envsubst <"${TEMPLATES_DIR}/mdb0.ldif" | tee dump-mdb0.ldif)
 slaptest -v -F conf.d

--- a/server/usr/local/bin/new-domain
+++ b/server/usr/local/bin/new-domain
@@ -23,6 +23,13 @@
 # shellcheck shell=dash disable=SC3001
 
 set -e # exit on error
+
+# Safety check: slapd must be stopped
+if pgrep -x slapd >/dev/null 2>&1; then
+    echo "[ERROR] slapd must be stopped before running $0" 1>&2
+    exit 1
+fi
+
 echo "Generating password hash for ${LDAP_ADMUSER:?}"
 tmpl_admpwh=$(slappasswd -s "${LDAP_ADMPASS:?}" -o module-load=pw-sha2.so -h '{SSHA512}')
 


### PR DESCRIPTION
- Change new-module behavior to always clean-up and rebuild the data volume. If the dump file exists, use it.
- Implement `import-module` action

Required by https://github.com/NethServer/nethserver-ns8-migration/pull/7