### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/tests/keywords.resource
+++ b/tests/keywords.resource
@@ -4,7 +4,7 @@ Resource    api.resource
 Variables   vars.py
 
 *** Variables ***
-${IMAGE_URL}    http://ghcr.io/nethserver/openldap:latest
+${IMAGE_URL}    https://ghcr.io/nethserver/openldap:latest
 ${DOMSUFFIX}    dc\=x,dc\=y
 ${MID1}         unknown00
 ${DOMSUFFIX}    dc\=x,dc\=y

--- a/tests/keywords.resource
+++ b/tests/keywords.resource
@@ -4,7 +4,7 @@ Resource    api.resource
 Variables   vars.py
 
 *** Variables ***
-${IMAGE_URL}    http://ghrc.io/nethserver/openldap:latest
+${IMAGE_URL}    http://ghcr.io/nethserver/openldap:latest
 ${DOMSUFFIX}    dc\=x,dc\=y
 ${MID1}         unknown00
 ${DOMSUFFIX}    dc\=x,dc\=y


### PR DESCRIPTION
Hi `NethServer/ns8-openldap`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used).
Please fix this typo and check your documentation for similar typos.