### PR TITLE
server: improve uid and gid allocation

### DIFF
--- a/server/usr/local/bin/add-group
+++ b/server/usr/local/bin/add-group
@@ -35,8 +35,8 @@ usage_error()
     exit 2
 }
 
-# XXX default ngid? e.g. max uidNumber + 1
-ngid=$(( 5000 + RANDOM % 10000 ))
+maxid=$(ldapsearch -b "ou=Groups,${LDAP_SUFFIX}" "(cn=*)" gidNumber | awk  '$0 ~ /^gidNumber:/ {print $2}' | sort -n | tail -n 1)
+ngid=$(( maxid + 1 ))
 
 while getopts "u:d:g:h" optname ; do
     case ${optname} in

--- a/server/usr/local/bin/add-user
+++ b/server/usr/local/bin/add-user
@@ -38,8 +38,8 @@ usage_error()
 }
 
 ngid=1001
-# XXX default nuid? e.g. max uidNumber + 1
-nuid=$(( 1003 + RANDOM % 8996 ))
+maxid=$(ldapsearch -b "ou=People,${LDAP_SUFFIX}" "(uid=*)" uidNumber | awk  '$0 ~ /^uidNumber:/ {print $2}' | sort -n | tail -n 1)
+nuid=$(( maxid + 1 ))
 
 while getopts "g:d:p:G:U:h" optname ; do
     case ${optname} in


### PR DESCRIPTION
uid and gid are now calculated from the maximum existing id + 1

See https://trello.com/c/ARx92kQN/181-core-p1-openldap-uidnumber-gidnumber-allocation