### PR TITLE
Allow starting domain name or FQDN with a numeric

### DIFF
--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -37,7 +37,7 @@
         "domain": {
             "type": "string",
             "title": "Domain name",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z][-a-zA-Z0-9]{0,62})+$",
+            "pattern": "^[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+$",
             "maxLength": 140,
             "minLength": 1
         }


### PR DESCRIPTION
This pull request updates the regular expression pattern for the "Domain name" field in the `validate-input.json` file. It now allows the domain name or FQDN to start with a numeric character. This change ensures that valid domain names and FQDNs can be entered correctly.

https://github.com/NethServer/dev/issues/6887