### PR TITLE
Fix LDAP dn splitting issue in get-password-policy handlers

### DIFF
--- a/imageroot/actions/get-password-policy/50get_password_policy
+++ b/imageroot/actions/get-password-policy/50get_password_policy
@@ -14,7 +14,7 @@ SECONDS_PER_DAY = 86400
 ldap_suffix = os.environ["LDAP_SUFFIX"]
 
 ldapsearch_proc = subprocess.run(["podman", "exec", "openldap",
-        "ldapsearch", "-LLL", "-b", f"cn=default,ou=PPolicy,{ldap_suffix}", "-s", "base"
+        "ldapsearch", "-LLLo", "ldif-wrap=no", "-b", f"cn=default,ou=PPolicy,{ldap_suffix}", "-s", "base"
     ], text=True, capture_output=True, check=True)
 
 

--- a/imageroot/api-moduled/handlers/get-configuration/post
+++ b/imageroot/api-moduled/handlers/get-configuration/post
@@ -15,7 +15,7 @@ ldap_suffix = os.environ["LDAP_SUFFIX"]
 
 # PASSWORD POLICY
 ldapsearch_proc = subprocess.run(["podman", "exec", "openldap",
-                                  "ldapsearch", "-LLL", "-b", f"cn=default,ou=PPolicy,{ldap_suffix}", "-s", "base"
+                                  "ldapsearch", "-LLLo", "ldif-wrap=no", "-b", f"cn=default,ou=PPolicy,{ldap_suffix}", "-s", "base"
                                   ], text=True, capture_output=True, check=True)
 
 ppolicy = {

--- a/imageroot/api-moduled/handlers/get-password-policy/post
+++ b/imageroot/api-moduled/handlers/get-password-policy/post
@@ -14,7 +14,7 @@ SECONDS_PER_DAY = 86400
 ldap_suffix = os.environ["LDAP_SUFFIX"]
 
 ldapsearch_proc = subprocess.run(["podman", "exec", "openldap",
-        "ldapsearch", "-LLL", "-b", f"cn=default,ou=PPolicy,{ldap_suffix}", "-s", "base"
+        "ldapsearch", "-LLLo", "ldif-wrap=no", "-b", f"cn=default,ou=PPolicy,{ldap_suffix}", "-s", "base"
     ], text=True, capture_output=True, check=True)
 
 


### PR DESCRIPTION
This PR set ldapsearch to not split the long domain name


refs: https://github.com/NethServer/dev/issues/6910


The fix concern long domain name, the ldapsearch command splits them with `\n`
```
[openldap3@R1-pve state]$ ../actions/get-password-policy/50get_password_policy
dn: cn=default,ou=PPolicy,dc=delabrusse,dc=nethvoice-proxy,dc=mv,dc=nethserver
 ,dc=rocky9-pve,dc=org
objectClass: namedPolicy
objectClass: pwdPolicy
objectClass: pwdPolicyChecker
cn: default
pwdAttribute: userPassword
pwdCheckQuality: 2
pwdMinAge: 0
pwdMaxAge: 15552000
pwdMinLength: 8
pwdInHistory: 12
pwdLockout: TRUE
pwdUseCheckModule: TRUE
pwdCheckModuleArg: default
pwdExpireWarning: 0
```

this is the example of a short domain name


```
[openldap1@R1-pve state]$ ../actions/get-password-policy/50get_password_policy
dn: cn=default,ou=PPolicy,dc=rocky9-pve,dc=org
objectClass: namedPolicy
objectClass: pwdPolicy
objectClass: pwdPolicyChecker
cn: default
pwdAttribute: userPassword
pwdCheckQuality: 2
pwdMinAge: 0
pwdMaxAge: 15552000
pwdMinLength: 8
pwdInHistory: 12
pwdLockout: TRUE
pwdUseCheckModule: TRUE
pwdCheckModuleArg: default
pwdExpireWarning: 0

```

