### PR TITLE
Fix LDAP dn splitting issue in remove-user script

### DIFF
--- a/server/usr/local/bin/remove-user
+++ b/server/usr/local/bin/remove-user
@@ -50,7 +50,7 @@ fi
     printf 'changetype: delete\n'
 
     # Delete user group membership attributes
-    ldapsearch -Q -LLL "(memberUid=${user})" dn | awk -v "user=${user}" -e '
+    ldapsearch -Q -LLL -o ldif-wrap=no "(memberUid=${user})" dn | awk -v "user=${user}" -e '
     /^dn: / {
         print ""
         print $0


### PR DESCRIPTION
This pull request fixes an issue in the remove-user script where LDAP dn splitting was not working correctly. The issue was resolved by updating the ldapsearch command to include the "-o ldif-wrap=no" option.

https://github.com/NethServer/dev/issues/6981
alter-user, add-user, add-group, alter-group have no issue with a long domain name

![image](https://github.com/user-attachments/assets/0fea93ea-0daa-4c77-b123-86e5773d53ea)
