### PR TITLE
Update url of documentation

### DIFF
--- a/ui/public/metadata.json
+++ b/ui/public/metadata.json
@@ -12,7 +12,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://docs.openldap.com/",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/user_domains.html#ldap-server-rfc2307",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/author/ns8-openldap"
   },


### PR DESCRIPTION
This pull request includes a single update to the `ui/public/metadata.json` file, changing the `documentation_url` to point to a more specific and relevant page about the LDAP server.

* Updated `documentation_url` in `ui/public/metadata.json` to reference the NethServer NS8 documentation on LDAP servers, replacing the generic OpenLDAP documentation link.

https://github.com/NethServer/dev/issues/7399