### PR TITLE
Enable slash redirection for users-admin path

### DIFF
--- a/imageroot/actions/configure-module/80start_amld
+++ b/imageroot/actions/configure-module/80start_amld
@@ -44,6 +44,7 @@ response = agent.tasks.run(
         'path': '/users-admin/' + os.environ['LDAP_DOMAIN'],
         'http2https': True,
         'strip_prefix': True,
+        'slash_redirect': True,
     },
 )
 


### PR DESCRIPTION
Add support for slash redirection in the users-admin route to improve URL handling.
`https://r2-pve.rocky9-pve2.org/users-admin/rocky9-pve2.org` and 
`https://r2-pve.rocky9-pve2.org/users-admin/rocky9-pve2.org/` are both workable
https://github.com/NethServer/dev/issues/7367