### PR TITLE
Add schema field to JSON output in user portal config

### DIFF
--- a/imageroot/bin/write-user-portal-config
+++ b/imageroot/bin/write-user-portal-config
@@ -37,7 +37,7 @@ except Exception as ex:
     print(agent.SD_WARNING + "Failed to run cluster/list-modules action:", ex, file=sys.stderr)
 
 # Write modules set to a JSON file
-data = {"domain": ldap_domain, "services": list(names_set)}
+data = {"domain": ldap_domain, "services": list(names_set), "schema":"rfc2307"}
 
 with open(f'{agent_install_dir}/api-moduled/public/config.json', 'w') as file:
     json.dump(data, file)


### PR DESCRIPTION
Include a schema field in the JSON output for the user portal configuration to enhance data structure.

NethServer/dev#7503