### PR TITLE
fix: preserve password-never-expires flag on password change

### DIFF
--- a/imageroot/api-moduled/handlers/change-password/post
+++ b/imageroot/api-moduled/handlers/change-password/post
@@ -72,7 +72,7 @@ if proc_lpasswd.returncode == 0:
             "ldapmodify", "-Q", "-e", "relax", "-c"],
             input=ldif, text=True, capture_output=True)
         if proc_relax.returncode != 0:
-            print(agent.SD_WARNING + "Failed to preserve password-never-expires flag: " + proc_relax.stdout + proc_relax.stderr, file=sys.stderr)
+            print(agent.SD_ERR + "Failed to preserve password-never-expires flag: " + proc_relax.stdout + proc_relax.stderr, file=sys.stderr)
     json.dump({"status": "success", "message": "password_changed"}, fp=sys.stdout)
 else:
     # Combined output

--- a/imageroot/api-moduled/handlers/change-password/post
+++ b/imageroot/api-moduled/handlers/change-password/post
@@ -28,6 +28,14 @@ except agent.ldapclient.exceptions.LdapclientEntryNotFound:
 
 oldapcli.ldapconn.unbind() # close LDAP connection FD
 
+# "Password never expires" means pwdChangedTime is absent. ldappasswd
+# makes the ppolicy overlay recreate it, so remember the state here to
+# restore the flag after a successful change.
+proc_pwdtime = subprocess.run(["podman", "exec", "-i", "openldap",
+    "ldapsearch", "-LLL", "-Q", "-b", ouser["dn"], "-s", "base", "pwdChangedTime"],
+    text=True, capture_output=True)
+password_never_expires = "pwdChangedTime:" not in proc_pwdtime.stdout
+
 # First attempt: try to change the password with simple bind, using the
 # user's credentials
 proc_lpasswd = subprocess.run(["podman", "exec", "-i", "openldap",
@@ -49,6 +57,15 @@ if proc_lpasswd.returncode == 49 and "Password expired" in proc_lpasswd.stderr:
 print(proc_lpasswd.stdout, file=sys.stderr)
 
 if proc_lpasswd.returncode == 0:
+    if password_never_expires:
+        # Re-delete the pwdChangedTime the overlay recreated (relax
+        # control), keeping the never-expires flag. Mirrors alter-user.
+        ldif = f"dn: {ouser['dn']}\nchangetype: modify\ndelete: pwdChangedTime\n"
+        proc_relax = subprocess.run(["podman", "exec", "-i", "openldap",
+            "ldapmodify", "-Q", "-e", "relax", "-c"],
+            input=ldif, text=True, capture_output=True)
+        if proc_relax.returncode != 0:
+            print(agent.SD_WARNING + f"Failed to preserve password-never-expires flag for {os.environ['JWT_ID']}: " + proc_relax.stdout + proc_relax.stderr, file=sys.stderr)
     json.dump({"status": "success", "message": "password_changed"}, fp=sys.stdout)
 else:
     # Combined output

--- a/imageroot/api-moduled/handlers/change-password/post
+++ b/imageroot/api-moduled/handlers/change-password/post
@@ -34,7 +34,14 @@ oldapcli.ldapconn.unbind() # close LDAP connection FD
 proc_pwdtime = subprocess.run(["podman", "exec", "-i", "openldap",
     "ldapsearch", "-LLL", "-Q", "-b", ouser["dn"], "-s", "base", "pwdChangedTime"],
     text=True, capture_output=True)
-password_never_expires = "pwdChangedTime:" not in proc_pwdtime.stdout
+# Only trust the result if the search succeeded: a failed ldapsearch
+# produces no stdout and must not be read as "flag set", which would
+# wrongly delete pwdChangedTime later and disable expiration.
+if proc_pwdtime.returncode != 0:
+    print(agent.SD_WARNING + "Cannot read pwdChangedTime, skipping never-expires preservation: " + proc_pwdtime.stderr, file=sys.stderr)
+    password_never_expires = False
+else:
+    password_never_expires = "pwdChangedTime:" not in proc_pwdtime.stdout
 
 # First attempt: try to change the password with simple bind, using the
 # user's credentials
@@ -65,7 +72,7 @@ if proc_lpasswd.returncode == 0:
             "ldapmodify", "-Q", "-e", "relax", "-c"],
             input=ldif, text=True, capture_output=True)
         if proc_relax.returncode != 0:
-            print(agent.SD_WARNING + f"Failed to preserve password-never-expires flag for {os.environ['JWT_ID']}: " + proc_relax.stdout + proc_relax.stderr, file=sys.stderr)
+            print(agent.SD_WARNING + "Failed to preserve password-never-expires flag: " + proc_relax.stdout + proc_relax.stderr, file=sys.stderr)
     json.dump({"status": "success", "message": "password_changed"}, fp=sys.stdout)
 else:
     # Combined output

--- a/server/usr/local/bin/alter-user
+++ b/server/usr/local/bin/alter-user
@@ -64,6 +64,18 @@ fi
 
 errors=0
 
+# ldappasswd makes the ppolicy overlay recreate pwdChangedTime. If the
+# user had "password never expires" (no pwdChangedTime) and the caller
+# did not ask to set/restore expiration, keep the flag: the nflag block
+# below will re-delete pwdChangedTime after the password change.
+if [ "${pflag}" = 1 ] && [ "${nflag}" != 1 ] && [ "${rflag}" != 1 ]; then
+    pwd_changed_time=$(ldapsearch -LLL -Q "(uid=${user})" pwdChangedTime 2>/dev/null \
+        | grep -i '^pwdChangedTime:')
+    if [ -z "${pwd_changed_time}" ]; then
+        nflag=1
+    fi
+fi
+
 if [ "${pflag}" = 1 ]; then
     if [ "${password}" = '-' ]; then
         echo -n "Enter password: "


### PR DESCRIPTION
Follow-up to #120.

The *password never expires* flag is just the absence of the `pwdChangedTime` attribute. But every `ldappasswd` makes the ppolicy overlay recreate `pwdChangedTime`, so changing a password silently re-enabled expiration and lost the flag.

This patch makes both password-change paths preserve the flag:

- `server/usr/local/bin/alter-user` — admin changes (also used by the `actions` and `api-moduled` alter-user handlers, which only call this helper).
- `imageroot/api-moduled/handlers/change-password/post` — self-service change, which calls `ldappasswd` directly and needed its own fix.

Both now check `pwdChangedTime` before the change and, if it was absent, re-delete it (with the `relax` control) after a successful change. The explicit `-n`/`-r` options of `alter-user` are unchanged.

https://github.com/NethServer/dev/issues/7981
