### PR TITLE
Fix migration/update of password expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ payload structure.
   to a NS8 compatible schema. The script `utils/genschema.py` was used to
   export NS8 schema data in Python format.
 - The password policy feature does not exist in NS7. When the NS7 LDAP
-  account provider is migrated to NS8 the password policy is set in a
-  disabled state and can be enabled later from the Domains and Users page
-  as usual.
+  account provider is migrated to NS8, the password policy starts in a
+  disabled state and can be enabled later from the Domains and Users page.
+- NS7 users with password-never-expires flag (`shadowMax: 99999`) are
+  migrated without the `pwdChangedTime` attribute. In NS8, that state is
+  treated as non-expiring.
+- If password expiration is later re-enabled for one of those users, the
+  current password is preserved and `pwdChangedTime` is initialized at that
+  point.

--- a/imageroot/actions/import-module/80fix_ppolicy
+++ b/imageroot/actions/import-module/80fix_ppolicy
@@ -48,19 +48,4 @@ pwdCheckModuleArg: default
 pwdExpireWarning: 0
 EOF
 
-podman exec -i openldap ash -s <<'EOF'
-{
-  ldapsearch -QLLLo ldif_wrap=no "(&(objectClass=inetOrgPerson)(!(pwdChangedTime=*))(!(pwdPolicySubentry=*)))" dn | \
-    awk -v "ldap_suffix=${LDAP_SUFFIX}" '
-    /^dn:/ {
-        print $0
-        print "changetype: modify"
-        print "add: pwdPolicySubentry"
-        print "pwdPolicySubentry: cn=neverexpires,ou=PPolicy," ldap_suffix
-        print "-"
-        print ""
-    }'
-} | ldapmodify -c -Q || :
-EOF
-
 exit 0

--- a/imageroot/pypkg/openldap.py
+++ b/imageroot/pypkg/openldap.py
@@ -7,12 +7,12 @@
 
 For export_users():
   - returns list of user records with keys: user, display_name, locked,
-    groups, mail, must_change_password (always False), no_password_expiration (always False)
+    groups, mail, must_change_password (always False), no_password_expiration
     (password is never exported).
 
 For import_users(records, skip_existing, progfunc):
   - records list items may contain: user (required), display_name, password,
-    locked, groups list, mail. Other AD-only flags ignored.
+    locked, groups list, mail, no_password_expiration. Other AD-only flags ignored.
   - When skip_existing is True existing users are skipped.
   - progfunc receives percentage progress (0-100).
 
@@ -37,6 +37,7 @@ ACTYPE = 5
 ACDISPLAY = 6
 ACMAIL = 7
 ACPWDLASTSET = 8
+ACPPOLICY = 9
 
 def export_users() -> list:
     # ldapcli returns: user, groups, ... plus optional attrs
@@ -49,7 +50,10 @@ def export_users() -> list:
             'user': u[ACID],
             'locked': bool(u[ACUAC]),
             'must_change_password': False,
-            'no_password_expiration': False,
+            'no_password_expiration': (
+                u[ACPWDLASTSET] is None
+                or u[ACPPOLICY] == f'cn=neverexpires,ou=PPolicy,{LDAP_SUFFIX}'
+            ),
         }
         if u[ACDISPLAY]:
             rec["display_name"] = u[ACDISPLAY]
@@ -99,6 +103,7 @@ def import_users(records: list, skip_existing: bool, progfunc) -> bool:
         password = rec.get('password') or None
         display_name = rec.get('display_name')
         mail = rec.get('mail')
+        no_password_expiration = rec.get('no_password_expiration')
         if user in adb:
             if skip_existing:
                 done += 1
@@ -120,6 +125,8 @@ def import_users(records: list, skip_existing: bool, progfunc) -> bool:
                 alt_cmd += ['-m', ''] # delete mail attribute
             elif mail:
                 alt_cmd += ['-m', mail] # replace value
+            if no_password_expiration is not None:
+                alt_cmd += ['-n'] if no_password_expiration else ['-r']
             alt_cmd.append(user)
             try:
                 subprocess.run(alt_cmd, input=password, stdout=sys.stderr, check=True, text=True)
@@ -141,6 +148,8 @@ def import_users(records: list, skip_existing: bool, progfunc) -> bool:
                 add_cmd += ['-d', user.title()]
             if mail:
                 add_cmd += ['-m', mail]
+            if no_password_expiration:
+                add_cmd += ['-n']
             add_cmd.append(user)
             try:
                 subprocess.run(add_cmd, input=password, stdout=sys.stderr, check=True, text=True)
@@ -157,7 +166,7 @@ def import_users(records: list, skip_existing: bool, progfunc) -> bool:
     return errors == 0
 
 def _get_accounts() -> dict:
-    """Returns users and groups. Each dict value is a list of 9 elements.
+    """Returns users and groups. Each dict value is a list of 10 elements.
     """
     def v(line):
         a, v = line.split(": ", 1)
@@ -169,7 +178,7 @@ def _get_accounts() -> dict:
         return v
 
     def _make_record():
-        record = list((None,)*9)
+        record = list((None,)*10)
         record[ACGROUPS] = []
         record[ACMEMBERS] = []
         record[ACTYPE] = 'U'
@@ -188,6 +197,7 @@ def _get_accounts() -> dict:
             'memberUid',
             'pwdAccountLockedTime',
             'pwdChangedTime',
+            'pwdPolicySubentry',
             'objectClass',
             'mail',
             'displayName',
@@ -235,6 +245,8 @@ def _get_accounts() -> dict:
                     except ValueError:
                         # Ignore invalid pwdChangedTime values; leave as None
                         pass
+                elif ldifline.startswith("pwdPolicySubentry:"):
+                    record[ACPPOLICY] = v(ldifline)
     # Fill group list of individual user records:
     group_iter = filter(lambda a: a[ACTYPE] == 'G', accounts.values())
     for g in group_iter:

--- a/imageroot/update-module.d/61add_neverexpires
+++ b/imageroot/update-module.d/61add_neverexpires
@@ -7,8 +7,6 @@
 
 #
 # - Define the "neverexpires" password policy, if it's missing.
-# - If missing, apply also "neverexpires" to existing users that have no
-#   pwdChangedTime attribute.
 #
 podman exec -i openldap ash -s <<'EOF'
 {
@@ -19,15 +17,5 @@ podman exec -i openldap ash -s <<'EOF'
     -e 's/^cn: default/cn: neverexpires/' \
     -e 's/^pwdMaxAge:.*/pwdMaxAge: 0/' \
     -e 's/^pwdExpireWarning:.*/pwdExpireWarning: 0/'
-  ldapsearch -QLLLo ldif_wrap=no "(&(objectClass=inetOrgPerson)(!(pwdChangedTime=*))(!(pwdPolicySubentry=*)))" dn | \
-    awk -v "ldap_suffix=${LDAP_SUFFIX}" '
-    /^dn:/ {
-        print $0
-        print "changetype: modify"
-        print "add: pwdPolicySubentry"
-        print "pwdPolicySubentry: cn=neverexpires,ou=PPolicy," ldap_suffix
-        print "-"
-        print ""
-    }'
 } | ldapmodify -Q || :
 EOF

--- a/server/README.md
+++ b/server/README.md
@@ -84,7 +84,7 @@ Other commands:
   already destroyed, the local slapd server must be running. Applied
   changes are propagated to other servers with syncrepl as usual.
 
-# Run with Podman
+## Run with Podman
 
 Create a `./lenv` file with the following contents
 
@@ -107,3 +107,19 @@ Start the service
 Enter the container
 
     podman exec -ti openldap ash
+
+## Password policy (ppolicy)
+
+- An additional `ppcheck.c` module is compiled and dynamically loaded by
+  slapd. It implements a simple password complexity check that requires a
+  mix of character types (see the code for details).
+- The default password policy is configured in `config.ldif`.
+- Individual users can select an alternative policy through the
+  `pwdPolicySubentry` attribute. For example, `neverexpires` disables
+  password expiration for that user.
+- As an alternative to the `neverexpires` policy, entries without the
+  `pwdChangedTime` operational attribute are also treated as non-expiring.
+  This is mainly used for users imported from NS7.
+- When a password is changed, `pwdChangedTime` is updated. When
+  `alter-user -r` switches an imported user back to the expiring policy, it
+  preserves the current password and adds the current timestamp.

--- a/server/usr/local/bin/alter-user
+++ b/server/usr/local/bin/alter-user
@@ -181,6 +181,11 @@ fi
         printf 'dn: uid=%s,ou=People,%s\n' "${user}" "${LDAP_SUFFIX:?}"
         printf 'changetype: modify\n'
         printf 'delete: pwdPolicySubentry\n'
+        printf '\n'
+        printf 'dn: uid=%s,ou=People,%s\n' "${user}" "${LDAP_SUFFIX:?}"
+        printf 'changetype: modify\n'
+        printf 'add: pwdChangedTime\n'
+        printf 'pwdChangedTime: %s\n' "$(date -u +%Y%m%d%H%M%SZ)"
     elif [ "${nflag}" = 1 ]; then
         printf '\n' # do not conflict with previous ldap commands
         printf 'dn: uid=%s,ou=People,%s\n' "${user}" "${LDAP_SUFFIX:?}"
@@ -189,7 +194,7 @@ fi
         printf 'pwdPolicySubentry: cn=neverexpires,ou=PPolicy,%s\n' "${LDAP_SUFFIX:?}"
     fi
 
-) | ldapmodify -Q -c
+) | ldapmodify -e relax -Q -c 2>/dev/null || :
 
 if [ "${errors}" != 0 ]; then
     exit 1

--- a/server/usr/local/bin/new-domain
+++ b/server/usr/local/bin/new-domain
@@ -53,6 +53,7 @@ if [ -f dump-mdb0.ldif ]; then
     slapadd -v -c -F conf.d -b "${LDAP_SUFFIX}" -l dump-mdb0.ldif
 else
     echo "Creating ${LDAP_SUFFIX} database for ${LDAP_DOMAIN}"
+    export TS_NOW="$(date -u +%Y%m%d%H%M%SZ)" # For mdb0.ldif template expansion
     slapadd -v -w -S "${LDAP_SERVERID}" -b "${LDAP_SUFFIX}" -F conf.d < <(envsubst <"${TEMPLATES_DIR}/mdb0.ldif" | tee dump-mdb0.ldif)
 fi
 slaptest -v -F conf.d

--- a/server/usr/local/lib/templates/mdb0.ldif
+++ b/server/usr/local/lib/templates/mdb0.ldif
@@ -86,3 +86,4 @@ objectClass: posixAccount
 objectClass: inetOrgPerson
 homeDirectory: /home/${LDAP_ADMUSER}
 pwdPolicySubentry: cn=neverexpires,ou=PPolicy,${LDAP_SUFFIX}
+pwdChangedTime: ${TS_NOW}

--- a/tests/50__users_admin.robot
+++ b/tests/50__users_admin.robot
@@ -70,6 +70,7 @@ Check if imported.user is present
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    "status":"success"
     Should Contain    ${output}    "user":"imported.user"
+    Should Contain    ${output}    "no_password_expiration":true
 
 Remove imported.user
     ${output}  ${error}  ${rc} =  Execute Command    curl -v -H "Authorization: Bearer ${TOKEN}" -H 'Content-type: application/json' --data '{"user":"imported.user"}' -k https://127.0.0.1/users-admin/${DOMAIN}/api/remove-user    return_rc=1  return_stderr=True


### PR DESCRIPTION
- A missing `pwdChangedTime` attribute or a `neverexpires` PPolicy means a user's password does not expire
- Migration and upgrade produces user entries without `pwdChangedTime` attribute
- The `alter-user` script can reset (`-r`) the policy setting `pwdChangedTime` to the current timestamp (failing silently if it is already set).

This PR also implement the import/export of the password expire flag, as already provided by Samba AD.

Refs NethServer/dev#7981