### PR TITLE
Reconfigure OpenLDAP replication when a module or node is removed

### DIFF
--- a/imageroot/actions/get-password-policy/50get_password_policy
+++ b/imageroot/actions/get-password-policy/50get_password_policy
@@ -9,13 +9,26 @@ import json
 import sys
 import subprocess
 import os
+import time
 
 SECONDS_PER_DAY = 86400
 ldap_suffix = os.environ["LDAP_SUFFIX"]
 
-ldapsearch_proc = subprocess.run(["podman", "exec", "openldap",
-        "ldapsearch", "-LLLo", "ldif-wrap=no", "-b", f"cn=default,ou=PPolicy,{ldap_suffix}", "-s", "base"
-    ], text=True, capture_output=True, check=True)
+# slapd may be momentarily unreachable (e.g. restarted to drop a stale replica
+# after a peer removal): retry only on "server down" conditions, so a genuine
+# LDAP error still fails fast.
+# 255 = ldapsearch cannot contact the server, 125 = podman container not running
+UNREACHABLE_CODES = (255, 125)
+for attempt in range(5):
+    try:
+        ldapsearch_proc = subprocess.run(["podman", "exec", "openldap",
+                "ldapsearch", "-LLLo", "ldif-wrap=no", "-b", f"cn=default,ou=PPolicy,{ldap_suffix}", "-s", "base"
+            ], text=True, capture_output=True, check=True)
+        break
+    except subprocess.CalledProcessError as ex:
+        if ex.returncode not in UNREACHABLE_CODES or attempt == 4:
+            raise
+        time.sleep(3)
 
 
 ppolicy = {

--- a/imageroot/actions/get-password-policy/50get_password_policy
+++ b/imageroot/actions/get-password-policy/50get_password_policy
@@ -14,10 +14,8 @@ import time
 SECONDS_PER_DAY = 86400
 ldap_suffix = os.environ["LDAP_SUFFIX"]
 
-# slapd may be momentarily unreachable (e.g. restarted to drop a stale replica
-# after a peer removal): retry only on "server down" conditions, so a genuine
-# LDAP error still fails fast.
-# 255 = ldapsearch cannot contact the server, 125 = podman container not running
+# Retry only while slapd is unreachable (255 = cannot contact, 125 = container
+# down, e.g. restarted after a peer removal); a real LDAP error still fails fast.
 UNREACHABLE_CODES = (255, 125)
 for attempt in range(5):
     try:

--- a/imageroot/events/module-removed/10remove-stale-replica
+++ b/imageroot/events/module-removed/10remove-stale-replica
@@ -29,6 +29,10 @@ removed = event.get("module", "")
 if not removed.startswith("openldap"):
     sys.exit(0)
 
+# Trust only the cluster agent: ignore events forged by apps or nodes.
+if os.getenv("AGENT_EVENT_SOURCE") != "cluster":
+    sys.exit(0)
+
 deadid = agent.get_module_seq(removed)
 myid = agent.get_module_seq(os.environ["MODULE_ID"])
 

--- a/imageroot/events/module-removed/10remove-stale-replica
+++ b/imageroot/events/module-removed/10remove-stale-replica
@@ -6,22 +6,10 @@
 #
 
 #
-# React to the removal of a peer module or node. When another openldap
-# provider of our domain disappears (remove-module, or remove-node with a
-# replica on it), its olcServerID/olcSyncrepl entries stay behind on the
-# survivors. Core deletes the dead module Redis keys and publishes
-# cluster/event/module-removed.
-#
-# Two things must happen on every surviving provider:
-#  1. Its replication config must drop the dead server. Each survivor runs
-#     `remove-server <deadid>` against its own local slapd. Doing it locally
-#     (instead of once on an elected node and relying on replication) avoids a
-#     race where the cleanup does not reach every peer. remove-server is
-#     idempotent, so it is a no-op where the config is already clean.
-#  2. Removing an olcSyncrepl entry at runtime does NOT stop the already
-#     running consumer thread (slapd keeps retrying the dead provider forever),
-#     so slapd must be restarted to drop the stale agreement. Restarts are
-#     staggered by server id so the providers do not all go down at once.
+# On module-removed, drop the removed openldap peer from the local replication
+# config and restart slapd. remove-server is run locally on each survivor (not
+# once via an elected node) to avoid a replication race; the restart is needed
+# because removing olcSyncrepl at runtime does not stop the consumer thread.
 #
 
 import os
@@ -52,22 +40,18 @@ domain = os.environ["LDAP_DOMAIN"]
 with agent.redis_connect() as rdb:
     domains = cluster.userdomains.get_internal_domains(rdb)
 
-# Survivors of our domain: the dead provider's srv/tcp/ldap key is already
-# gone, so get_internal_domains lists only the remaining providers.
+# Surviving providers (the dead one's srv/tcp/ldap key is already gone).
 providers = domains.get(domain, {}).get("providers", [])
 live = sorted({int(p["id"].removeprefix("openldap")) for p in providers})
 
 if not live or myid not in live:
     sys.exit(0)
 
-# Drop the dead server from the local replication config. remove-server is
-# idempotent (no-op when deadid is not part of this domain or already gone),
-# so its exit code is intentionally not checked.
+# remove-server is idempotent, so its exit code is intentionally not checked.
 print(f"Removing stale replica openldap{deadid} from the {domain} replication config", file=sys.stderr)
 agent.run_helper("podman", "exec", "openldap", "remove-server", str(deadid))
 
-# Restart slapd to drop the lingering consumer thread. Stagger by rank so the
-# providers do not all restart at the same moment.
+# Stagger the restart by rank so the providers do not all go down at once.
 rank = live.index(myid)
 if rank > 0:
     time.sleep(rank * 8)

--- a/imageroot/events/module-removed/10remove-stale-replica
+++ b/imageroot/events/module-removed/10remove-stale-replica
@@ -8,8 +8,11 @@
 #
 # On module-removed, drop the removed openldap peer from the local replication
 # config and restart slapd. remove-server is run locally on each survivor (not
-# once via an elected node) to avoid a replication race; the restart is needed
-# because removing olcSyncrepl at runtime does not stop the consumer thread.
+# once via an elected node) to avoid a replication race. The restart is needed
+# because deleting olcSyncrepl at runtime does not reliably stop the running
+# consumer thread (slapd handles the change as delete+add and we cannot rely on
+# a clean teardown), so the thread keeps retrying the dead provider until slapd
+# is restarted. See https://openldap.org/lists/openldap-technical/201109/msg00023.html
 #
 
 import os

--- a/imageroot/events/module-removed/10remove-stale-replica
+++ b/imageroot/events/module-removed/10remove-stale-replica
@@ -21,7 +21,6 @@ import json
 import time
 
 import agent
-import cluster.userdomains
 
 event = json.load(sys.stdin)
 removed = event.get("module", "")
@@ -30,8 +29,8 @@ removed = event.get("module", "")
 if not removed.startswith("openldap"):
     sys.exit(0)
 
-deadid = int(removed.removeprefix("openldap"))
-myid = int(os.environ["MODULE_ID"].removeprefix("openldap"))
+deadid = agent.get_module_seq(removed)
+myid = agent.get_module_seq(os.environ["MODULE_ID"])
 
 # Self-removal is handled by the leave-domain action; remove-server refuses
 # to drop the local server anyway.
@@ -41,11 +40,10 @@ if deadid == myid:
 domain = os.environ["LDAP_DOMAIN"]
 
 with agent.redis_connect() as rdb:
-    domains = cluster.userdomains.get_internal_domains(rdb)
+    providers = agent.list_service_providers(rdb, "ldap", "tcp", filters={"domain": domain})
 
 # Surviving providers (the dead one's srv/tcp/ldap key is already gone).
-providers = domains.get(domain, {}).get("providers", [])
-live = sorted({int(p["id"].removeprefix("openldap")) for p in providers})
+live = sorted({provider["module_seq"] for provider in providers})
 
 if not live or myid not in live:
     sys.exit(0)

--- a/imageroot/events/module-removed/10remove-stale-replica
+++ b/imageroot/events/module-removed/10remove-stale-replica
@@ -10,14 +10,23 @@
 # provider of our domain disappears (remove-module, or remove-node with a
 # replica on it), its olcServerID/olcSyncrepl entries stay behind on the
 # survivors. Core deletes the dead module Redis keys and publishes
-# cluster/event/module-removed. One surviving provider (the lowest server id)
-# runs `remove-server <deadid>` against its own running slapd; mirror-mode
-# replication propagates the cleaned config to the other survivors.
+# cluster/event/module-removed.
+#
+# Two things must happen on the survivors:
+#  1. The replication config must drop the dead server. One elected provider
+#     (the lowest server id) runs `remove-server <deadid>` against its own
+#     running slapd; mirror-mode replication propagates the change to the rest.
+#  2. Removing an olcSyncrepl entry at runtime does NOT stop the already
+#     running consumer thread (slapd keeps retrying the dead provider forever).
+#     Every surviving provider must therefore restart slapd to drop the stale
+#     agreement. Restarts are staggered by server id so the providers do not
+#     all go down at the same moment.
 #
 
 import os
 import sys
 import json
+import time
 
 import agent
 import cluster.userdomains
@@ -45,16 +54,23 @@ with agent.redis_connect() as rdb:
 # Survivors of our domain: the dead provider's srv/tcp/ldap key is already
 # gone, so get_internal_domains lists only the remaining providers.
 providers = domains.get(domain, {}).get("providers", [])
-live = {int(p["id"].removeprefix("openldap")) for p in providers}
+live = sorted({int(p["id"].removeprefix("openldap")) for p in providers})
 
-# Single-executor election: only the lowest surviving server id acts, the
-# others receive the cleaned configuration through replication.
-if not live or myid != min(live):
+if not live or myid not in live:
     sys.exit(0)
 
-print(f"Removing stale replica openldap{deadid} from the {domain} replication config", file=sys.stderr)
+# Authoritative config cleanup runs once, on the lowest surviving server id.
+# remove-server is idempotent: if the graceful leave-domain path already
+# cleaned the config, or deadid is not part of this domain, it is a no-op.
+if myid == live[0]:
+    print(f"Removing stale replica openldap{deadid} from the {domain} replication config", file=sys.stderr)
+    agent.run_helper("podman", "exec", "openldap", "remove-server", str(deadid)).check_returncode()
 
-# remove-server runs against the local running slapd (SASL EXTERNAL over
-# ldapi). It is idempotent: if deadid is not part of this domain's config it
-# is a no-op.
-agent.run_helper("podman", "exec", "openldap", "remove-server", str(deadid)).check_returncode()
+# Restart slapd to drop the lingering consumer thread. Stagger by rank so the
+# config cleanup has time to replicate and providers do not restart in unison.
+rank = live.index(myid)
+if rank > 0:
+    time.sleep(rank * 8)
+
+print("Restarting slapd to drop the stale replication agreement", file=sys.stderr)
+agent.run_helper("systemctl", "--user", "try-restart", "openldap.service").check_returncode()

--- a/imageroot/events/module-removed/10remove-stale-replica
+++ b/imageroot/events/module-removed/10remove-stale-replica
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+#
+# React to the removal of a peer module or node. When another openldap
+# provider of our domain disappears (remove-module, or remove-node with a
+# replica on it), its olcServerID/olcSyncrepl entries stay behind on the
+# survivors. Core deletes the dead module Redis keys and publishes
+# cluster/event/module-removed. One surviving provider (the lowest server id)
+# runs `remove-server <deadid>` against its own running slapd; mirror-mode
+# replication propagates the cleaned config to the other survivors.
+#
+
+import os
+import sys
+import json
+
+import agent
+import cluster.userdomains
+
+event = json.load(sys.stdin)
+removed = event.get("module", "")
+
+# Only care about other openldap providers
+if not removed.startswith("openldap"):
+    sys.exit(0)
+
+deadid = int(removed.removeprefix("openldap"))
+myid = int(os.environ["MODULE_ID"].removeprefix("openldap"))
+
+# Self-removal is handled by the leave-domain action; remove-server refuses
+# to drop the local server anyway.
+if deadid == myid:
+    sys.exit(0)
+
+domain = os.environ["LDAP_DOMAIN"]
+
+with agent.redis_connect() as rdb:
+    domains = cluster.userdomains.get_internal_domains(rdb)
+
+# Survivors of our domain: the dead provider's srv/tcp/ldap key is already
+# gone, so get_internal_domains lists only the remaining providers.
+providers = domains.get(domain, {}).get("providers", [])
+live = {int(p["id"].removeprefix("openldap")) for p in providers}
+
+# Single-executor election: only the lowest surviving server id acts, the
+# others receive the cleaned configuration through replication.
+if not live or myid != min(live):
+    sys.exit(0)
+
+print(f"Removing stale replica openldap{deadid} from the {domain} replication config", file=sys.stderr)
+
+# remove-server runs against the local running slapd (SASL EXTERNAL over
+# ldapi). It is idempotent: if deadid is not part of this domain's config it
+# is a no-op.
+agent.run_helper("podman", "exec", "openldap", "remove-server", str(deadid)).check_returncode()

--- a/imageroot/events/module-removed/10remove-stale-replica
+++ b/imageroot/events/module-removed/10remove-stale-replica
@@ -12,15 +12,16 @@
 # survivors. Core deletes the dead module Redis keys and publishes
 # cluster/event/module-removed.
 #
-# Two things must happen on the survivors:
-#  1. The replication config must drop the dead server. One elected provider
-#     (the lowest server id) runs `remove-server <deadid>` against its own
-#     running slapd; mirror-mode replication propagates the change to the rest.
+# Two things must happen on every surviving provider:
+#  1. Its replication config must drop the dead server. Each survivor runs
+#     `remove-server <deadid>` against its own local slapd. Doing it locally
+#     (instead of once on an elected node and relying on replication) avoids a
+#     race where the cleanup does not reach every peer. remove-server is
+#     idempotent, so it is a no-op where the config is already clean.
 #  2. Removing an olcSyncrepl entry at runtime does NOT stop the already
-#     running consumer thread (slapd keeps retrying the dead provider forever).
-#     Every surviving provider must therefore restart slapd to drop the stale
-#     agreement. Restarts are staggered by server id so the providers do not
-#     all go down at the same moment.
+#     running consumer thread (slapd keeps retrying the dead provider forever),
+#     so slapd must be restarted to drop the stale agreement. Restarts are
+#     staggered by server id so the providers do not all go down at once.
 #
 
 import os
@@ -59,15 +60,14 @@ live = sorted({int(p["id"].removeprefix("openldap")) for p in providers})
 if not live or myid not in live:
     sys.exit(0)
 
-# Authoritative config cleanup runs once, on the lowest surviving server id.
-# remove-server is idempotent: if the graceful leave-domain path already
-# cleaned the config, or deadid is not part of this domain, it is a no-op.
-if myid == live[0]:
-    print(f"Removing stale replica openldap{deadid} from the {domain} replication config", file=sys.stderr)
-    agent.run_helper("podman", "exec", "openldap", "remove-server", str(deadid)).check_returncode()
+# Drop the dead server from the local replication config. remove-server is
+# idempotent (no-op when deadid is not part of this domain or already gone),
+# so its exit code is intentionally not checked.
+print(f"Removing stale replica openldap{deadid} from the {domain} replication config", file=sys.stderr)
+agent.run_helper("podman", "exec", "openldap", "remove-server", str(deadid))
 
 # Restart slapd to drop the lingering consumer thread. Stagger by rank so the
-# config cleanup has time to replicate and providers do not restart in unison.
+# providers do not all restart at the same moment.
 rank = live.index(myid)
 if rank > 0:
     time.sleep(rank * 8)

--- a/server/usr/local/lib/awk/update-syncrepl.awk
+++ b/server/usr/local/lib/awk/update-syncrepl.awk
@@ -25,9 +25,8 @@
 #
 # This awk filter reads the current configuration database and prints an LDIF
 # script that removes server and syncrepl entries for the given "targetid".
-# The syncrepl entries are matched by their rid, which is derived from the
-# server id (config rid = targetid * 2, data rid = targetid * 2 + 1), so the
-# removal also works when the olcServerID entry is already gone.
+# Syncrepl entries are matched by rid (config rid = targetid * 2, data rid + 1),
+# so removal works even when the olcServerID entry is already gone.
 #
 
 BEGIN {

--- a/server/usr/local/lib/awk/update-syncrepl.awk
+++ b/server/usr/local/lib/awk/update-syncrepl.awk
@@ -4,7 +4,7 @@
 # Copyright (C) 2022 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
 #
-# This script is part of NethServer.
+# This file is part of NethServer.
 #
 # NethServer is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,19 +13,26 @@
 #
 # NethServer is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with NethServer.  If not, see COPYING.
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
 
 #
-# Remove server "targetid" from the syncrepl configuration.
+# Remove server "targetid" from the syncrepl configuration and emit the
+# resulting LDIF on stdout.
 #
-# This awk filter reads the current configuration database and prints an LDIF
-# script that removes server and syncrepl entries for the given "targetid"
+# The replication agreements pointing at a server are matched by their rid,
+# which is derived deterministically from the server id (see entrypoint.sh):
+#   config rid = targetid * 2
+#   data   rid = targetid * 2 + 1
+# Matching by rid (instead of the provider URL taken from the olcServerID
+# entry) makes the removal work even when the olcServerID entry is already
+# gone, e.g. after the graceful leave-domain path ran first.
 #
+
+BEGIN {
+    config_rid = targetid * 2
+    data_rid = config_rid + 1
+}
 
 /^dn: / {
     lastdn = $2
@@ -42,7 +49,6 @@
 /^olcServerID: / {
     servers_left++
     if (targetid == $2) {
-        providermatch = " provider=" $3 " "
         print "dn: cn=config"
         print "changetype: modify"
         print "delete: olcServerID"
@@ -52,8 +58,8 @@
 }
 
 /^olcSyncrepl: / {
-    if(servers_left < 2) {
-        # Remove replication attributes
+    if (servers_left < 2) {
+        # Only one server will remain: drop replication entirely
         print "dn: " lastdn
         print "changetype: modify"
         print "replace: olcSyncrepl"
@@ -62,8 +68,8 @@
         # Turn on the flag to skip remaining lines of the current dn entry:
         skipentry = 1
         next
-    } else if (providermatch && $0 ~ providermatch) {
-        # Expunge syncrepl config for targetid only
+    } else if ($0 ~ ("}rid=" config_rid " ") || $0 ~ ("}rid=" data_rid " ")) {
+        # Expunge the syncrepl agreement of targetid only
         print "dn: " lastdn
         print "changetype: modify"
         print "delete: olcSyncrepl"

--- a/server/usr/local/lib/awk/update-syncrepl.awk
+++ b/server/usr/local/lib/awk/update-syncrepl.awk
@@ -4,7 +4,7 @@
 # Copyright (C) 2022 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
 #
-# This file is part of NethServer.
+# This script is part of NethServer.
 #
 # NethServer is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,20 +13,21 @@
 #
 # NethServer is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
 #
 
 #
-# Remove server "targetid" from the syncrepl configuration and emit the
-# resulting LDIF on stdout.
+# Remove server "targetid" from the syncrepl configuration.
 #
-# The replication agreements pointing at a server are matched by their rid,
-# which is derived deterministically from the server id (see entrypoint.sh):
-#   config rid = targetid * 2
-#   data   rid = targetid * 2 + 1
-# Matching by rid (instead of the provider URL taken from the olcServerID
-# entry) makes the removal work even when the olcServerID entry is already
-# gone, e.g. after the graceful leave-domain path ran first.
+# This awk filter reads the current configuration database and prints an LDIF
+# script that removes server and syncrepl entries for the given "targetid".
+# The syncrepl entries are matched by their rid, which is derived from the
+# server id (config rid = targetid * 2, data rid = targetid * 2 + 1), so the
+# removal also works when the olcServerID entry is already gone.
 #
 
 BEGIN {
@@ -58,8 +59,8 @@ BEGIN {
 }
 
 /^olcSyncrepl: / {
-    if (servers_left < 2) {
-        # Only one server will remain: drop replication entirely
+    if(servers_left < 2) {
+        # Remove replication attributes
         print "dn: " lastdn
         print "changetype: modify"
         print "replace: olcSyncrepl"
@@ -69,7 +70,7 @@ BEGIN {
         skipentry = 1
         next
     } else if ($0 ~ ("}rid=" config_rid " ") || $0 ~ ("}rid=" data_rid " ")) {
-        # Expunge the syncrepl agreement of targetid only
+        # Expunge syncrepl config for targetid only
         print "dn: " lastdn
         print "changetype: modify"
         print "delete: olcSyncrepl"


### PR DESCRIPTION
## Problem

Ref: NethServer/dev#7841

When an OpenLDAP replica is removed from the cluster — either `remove-module` on a
provider, or `remove-node` on a node that hosts one — the surviving providers keep
stale `olcServerID` / `olcSyncrepl` entries pointing at the gone replica. slapd then
retries the dead provider forever (`slap_client_connect ... ldap_sasl_bind_s failed`,
`do_syncrepl rid=NNN rc -1 retrying`).

The graceful `leave-domain` action only covers the case where the departing node is
online and cooperative. When the node is offline (the #7841 scenario: dead leader
removed after `switch-leader`) nothing tells the survivors to drop it.

## Solution

The fix lives entirely in openldap; core already emits the right event.

`remove-module` and `remove-node` both publish `cluster/event/module-removed`
`{"module": "<id>", "node": <n>}` (remove-node publishes one per module on the dead
node). A new handler reacts to it:

`imageroot/events/module-removed/10remove-stale-replica`
- Ignores non-openldap modules and self-removal.
- Every surviving provider of the domain cleans its **own** local config with
  `podman exec openldap remove-server <deadid>` (idempotent), then restarts slapd,
  staggered by server id. Cleaning locally instead of once-on-an-elected-node avoids
  a replication race that left some peers with stale mdb agreements.

Two problems surfaced during testing and are fixed here too:

1. `server/usr/local/lib/awk/update-syncrepl.awk` matched agreements by the provider
   URL read from the `olcServerID` entry. When `leave-domain` had already removed that
   entry, the match failed and left agreements behind. It now matches by **rid**
   (`config rid = id*2`, `data rid = id*2+1`), which is deterministic from the server
   id and works even when `olcServerID` is gone. This also fixes the graceful path.

2. Deleting an `olcSyncrepl` entry at runtime does not reliably stop the running
   consumer thread — slapd treats the change as delete+add and the consumer is not
   torn down cleanly, so it keeps retrying the dead provider until the process is
   restarted. Hence the slapd restart on every survivor. Adding a replica does not
   need a restart (slapd starts the new consumer live); only removal does.
   Ref: https://openldap.org/lists/openldap-technical/201109/msg00023.html

`get-password-policy` is refreshed by the UI right after a provider removal and could
hit the slapd restart window; it now retries a few times, but only on
server-unreachable conditions (ldapsearch 255 / podman 125) so a genuine LDAP error
still fails fast.

## Files

- **New**: `imageroot/events/module-removed/10remove-stale-replica`
- **Changed**: `server/usr/local/lib/awk/update-syncrepl.awk` (match by rid)
- **Changed**: `imageroot/actions/get-password-policy/50get_password_policy` (retry on restart)

## Testing

Validated on a live cluster across scenarios, checking that no survivor keeps a
`do_syncrepl rid=... -> <dead ip>` loop and that the config is consistent everywhere:
- `remove-module` on a provider
- `remove-node` with a replica on it (the #7841 offline-leader flow)
- 3 → 2 providers (agreements of the removed server dropped, cluster stays multi-provider)
- 2 → 1 provider (replication collapses back to standalone)
- online path (`leave-domain`) and offline path

## Known limitation (event delivery)

`module-removed` is a Redis pub/sub event: it is delivered only to providers online at
publish time. A provider that misses it (node powered off during the removal, or a
Redis full resync) does not run the handler. In practice this self-heals: mirror-mode
replication of `cn=config` propagates the deletion from a surviving peer, and a later
slapd restart drops the lingering consumer thread; data is never lost because the live
peer's agreement keeps replicating. A start-time reconciliation (drop config agreements
whose provider is no longer a live domain member) would close the gap fully and can be
handled as a follow-up.

Out of scope: an unrelated `ns8-ldapproxy` template crash (`NoneType + str` in
`nginx.conf.j2` when a provider has an empty endpoint) — tracked separately.