### PR TITLE
fix(systemd): replace %S with %E in unit files

### DIFF
--- a/imageroot/systemd/user/openldap.service
+++ b/imageroot/systemd/user/openldap.service
@@ -3,7 +3,7 @@ Description=OpenLDAP directory server
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/openldap.pid %t/openldap.ctr-id
@@ -27,7 +27,7 @@ ExecStop=/usr/bin/podman stop --ignore --cidfile %t/openldap.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/openldap.ctr-id
 PIDFile=%t/openldap.pid
 Type=forking
-WorkingDirectory=%S/state
+WorkingDirectory=%E/state
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Summary
- Newer systemd releases (Rocky Linux 9.8+, Debian 13) changed the `%S` specifier to expand to `~/.local/state` instead of `~/.config`, breaking units that relied on the old behavior to reference the config/state directory.
- Replaced `%S` with `%E` across all affected systemd user unit files. `%E` expands to `~/.config` on both old and new systemd, making the units forward-compatible.

Related: NethServer/dev#8029

## Test plan
- [ ] Verify units still parse (`systemd-analyze verify`) on a test node
- [ ] Confirm services start correctly on both an old (Rocky 9.x pre-9.8) and new (Rocky 9.8+/Debian 13) systemd host